### PR TITLE
Answers_post_id is the first number after a/

### DIFF
--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -678,7 +678,7 @@ def interne_link(text_post, domain,id):
                 a.attrib['href']="../tag/" + tag + ".html"
             elif link[0:2] == "a/":
                 qans_split = link.split("/")
-                quans=qans_split[1]
+                qans=qans_split[1]
                 a.attrib['href']="../answer/" + qans + ".html#a" + qans
             elif link[0:6] == "users/":
                 userid=link.split("/")[1]

--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -678,10 +678,7 @@ def interne_link(text_post, domain,id):
                 a.attrib['href']="../tag/" + tag + ".html"
             elif link[0:2] == "a/":
                 qans_split = link.split("/")
-                if len(qans_split) == 3:
-                    qans=link.split("/")[2]
-                else:
-                    qans=link.split("/")[1]
+                quans=qans_split[1]
                 a.attrib['href']="../answer/" + qans + ".html#a" + qans
             elif link[0:6] == "users/":
                 userid=link.split("/")[1]


### PR DESCRIPTION
According to [this answer](https://meta.stackexchange.com/a/164197) the part after / in a link is an user id and useless in our case.

As explain in #68 59 is not the right answer_post_id but it is the user_id of user who post the question.

fix #68 