### PR TITLE
Added a warning before start of dump decompress

### DIFF
--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -1112,6 +1112,7 @@ def download_dump(domain, dump_path):
         os.remove(domain + ".hash")
         os.remove(domain + ".7z")
         sys.exit(1)
+    print("Starting to decompress dump, may take a very long time depending on dump size")
     exec_cmd("7z e " + domain + ".7z -o" + dump_path)
     os.remove(domain + ".hash")
     os.remove(domain + ".7z")


### PR DESCRIPTION
The decompression of dump files can take an extremely long time. Hence, it is appropriate to send a warning before the process begins.

This PR provides a solution to [Issue 91](https://github.com/openzim/sotoki/issues/91).