### PR TITLE
Fixed #85: using different temp path for imagemagick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Enabled Mathjax everywhere (#98)
 * Fixed redirects by fixing redirects TSV format (#95)
 * Introduced changelog (#88)
+* Fixed /tmp being filled with files (#88)
+* Changed image optimization timeout (20s vs 10s before)
 
 ## 1.1.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ docopt==0.6.2
 python-slugify==4.0.0
 pydenticon==0.3.1
 beautifulsoup4==4.8.2
-subprocess32==3.5.4
 filemagic==1.6
 mistune>=2.0.0a2
 Pillow==7.0.0

--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -1008,6 +1008,7 @@ def exec_cmd(cmd, timeout=None):
     except Exception as e:
         print(e)
 
+
 def bin_is_present(binary):
     try:
         subprocess.Popen(
@@ -1053,17 +1054,17 @@ def prepare(dump_path, bin_dir):
 
 def optimize_one(path, ftype):
     if ftype == "jpeg":
-        exec_cmd("jpegoptim --strip-all -m50 " + path, timeout=10)
+        exec_cmd("jpegoptim --strip-all -m50 " + path, timeout=20)
     elif ftype == "png":
-        exec_cmd("pngquant --verbose --nofs --force --ext=.png " + path, timeout=10)
-        exec_cmd("advdef -q -z -4 -i 5  " + path, timeout=10)
+        exec_cmd("pngquant --verbose --nofs --force --ext=.png " + path, timeout=20)
+        exec_cmd("advdef -q -z -4 -i 5  " + path, timeout=20)
     elif ftype == "gif":
-        exec_cmd("gifsicle --batch -O3 -i " + path, timeout=10)
+        exec_cmd("gifsicle --batch -O3 -i " + path, timeout=20)
 
 
 def resize_one(path, ftype, nb_pix):
     if ftype in ["gif", "png", "jpeg"]:
-        exec_cmd("mogrify -resize " + nb_pix + r"x\> " + path, timeout=10)
+        exec_cmd("mogrify -resize " + nb_pix + r"x\> " + path, timeout=20)
 
 
 def create_temporary_copy(path):
@@ -1111,7 +1112,9 @@ def download_dump(domain, dump_path):
         os.remove(domain + ".hash")
         os.remove(domain + ".7z")
         sys.exit(1)
-    print("Starting to decompress dump, may take a very long time depending on dump size")
+    print(
+        "Starting to decompress dump, may take a very long time depending on dump size"
+    )
     exec_cmd("7z e " + domain + ".7z -o" + dump_path)
     os.remove(domain + ".hash")
     os.remove(domain + ".7z")


### PR DESCRIPTION
- inside build directory (as /magick)
- removed once complete

Also replaced `subprocess32` (dep) with `subprocess` (stdlib) as not required anymore.
Adding a print on image optimization timeout
Increasing image optim timeouts