### PR TITLE
Image optim and resize in memory (/dev/shm) if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Introduced changelog (#88)
 * Fixed /tmp being filled with files (#88)
 * Changed image optimization timeout (20s vs 10s before)
+* Image optim and resize in memory (/dev/shm) if possible (#84)
 
 ## 1.1.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN wget https://www.lcdf.org/gifsicle/gifsicle-1.88.tar.gz && \
 
 # Install sotoki
 RUN locale-gen "en_US.UTF-8"
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install -r /tmp/requirements.txt
 COPY . /app
 WORKDIR /app
 RUN pip3 install .


### PR DESCRIPTION
This is an alternative solution to #84 that should be safer and more efficient than #101 

- combined download and optimization of image in a single function
- downloads to `/dev/shm` if avail (linux)
- optimize in place (or in the same dir -- gif resize)
- move file from there to requested path
- use same function for both profile pics and images