### PR TITLE
Fixes #108 - Bump mistune version to 2.0.0a3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ python-slugify==4.0.0
 pydenticon==0.3.1
 beautifulsoup4==4.8.2
 python-magic==0.4.15
-mistune>=2.0.0a2
+mistune>=2.0.0a3
 Pillow==7.0.0

--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -399,11 +399,11 @@ def some_questions(
                 nopic=nopic,
             )
         except Exception as e:
-            print(" * failed to generate: %s" % filepath)
-            print("erreur jinja" + str(e))
+            print("Failed to generate %s" % filepath)
+            print("Error with jinja" + str(e))
             print(question)
     except Exception as e:
-        print("Erreur with one post : " + str(e))
+        print("Error with a post : " + str(e))
 
 
 #########################


### PR DESCRIPTION
This fixes #108 and some small typos in sotoki.py

Previously the following thew error in processing questions (At around 96000 questions)
`sotoki wordpress.stackexchange.com Kiwix --threads=1 --reset --clean-previous --no-userprofile --nopic --nozim`
However, this works as expected now.