### PR TITLE
Bump dependencies to latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pydenticon==0.3.1
 beautifulsoup4==4.9.0
 python-magic==0.4.15
 mistune>=2.0.0a2
-Pillow==7.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ MarkupSafe==1.1.1
 docopt==0.6.2
 python-slugify==4.0.0
 pydenticon==0.3.1
-beautifulsoup4==4.8.2
+beautifulsoup4==4.9.0
 python-magic==0.4.15
 mistune>=2.0.0a2
-Pillow==7.0.0
+Pillow==7.1.1

--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -50,7 +50,6 @@ from urllib.request import urlopen
 import magic
 import mistune  # markdown
 import pydenticon
-from PIL import Image
 from slugify import slugify
 import bs4 as BeautifulSoup
 from jinja2 import Environment


### PR DESCRIPTION
This bumps beautifulsoup4 and Pillow to their latest versions. I have verified that the scraper works and everything seems to work properly. However, @rgaudin, @dattaz please check this once.