### PR TITLE
Less dependence on ImageMagick and better filetype identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### 1.3.1
 
 * fixed identicons for missing source image (#142)
+- log on successful downloads
+- do not depend on headers for filetype identification
+- use Pillow to convert images (except GIF) to PNG
+- use Pillow to resize images (except GIF)
 
 ### 1.3
 


### PR DESCRIPTION
This does the following -
- log on successful downloads
- do not depend on headers for filetype identification
- use Pillow to convert images (except GIF) to PNG
- use Pillow to resize images (except GIF)

Fixes #147 and #146 by not depending on ImageMagick (except for GIFs) and not using content-type header for filetype identification.

Also, adds logs on successful downloads/uploads because it seems that it may play in important role in further debugging.