### PR TITLE
Add --no-tmpfs-dir

### DIFF
--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -5,7 +5,7 @@
 """sotoki.
 
 Usage:
-  sotoki <domain> <publisher> [--directory=<dir>] [--nozim] [--tag-depth=<tag_depth>] [--threads=<threads>] [--zimpath=<zimpath>] [--optimization-cache=<optimization-cache>] [--reset] [--reset-images] [--clean-previous] [--nofulltextindex] [--ignoreoldsite] [--nopic] [--no-userprofile]
+  sotoki <domain> <publisher> [--directory=<dir>] [--no-tmpfs-dir] [--nozim] [--tag-depth=<tag_depth>] [--threads=<threads>] [--zimpath=<zimpath>] [--optimization-cache=<optimization-cache>] [--reset] [--reset-images] [--clean-previous] [--nofulltextindex] [--ignoreoldsite] [--nopic] [--no-userprofile]
   sotoki (-h | --help)
   sotoki --version
 
@@ -13,6 +13,7 @@ Options:
   -h --help                                     Display this help
   --version                                     Display the version of Sotoki
   --directory=<dir>                             Configure directory in which XML files will be stored [default: download]
+  --no-tmpfs-dir                                Don't use /dev/shm downloading and optimizing temporary files
   --nozim                                       Doesn't build a ZIM file, output will be in 'work/output/' in flat HTML files (otherwise 'work/ouput/' will be in deflated form and will produce a ZIM file)
   --tag-depth=<tag_depth>                       Configure the number of questions, ordered by Score, to display in tags pages (should be a multiple of 100, default all question are in tags pages) [default: -1]
   --threads=<threads>                           Number of threads to use, default is number_of_cores/2
@@ -1449,6 +1450,10 @@ def run():
     except DocoptExit:
         print(__doc__)
         sys.exit()
+    if arguments["--no-tmpfs-dir"]:
+        global TMPFS_DIR
+        TMPFS_DIR = None
+
     print(
         "starting sotoki scraper...{}".format(f"using {TMPFS_DIR}" if TMPFS_DIR else "")
     )


### PR DESCRIPTION
This adds --no-tmpfs-dir to set TMPFS_DIR to None even if we have /dev/shm available. This will help narrow down #145 

This is a temporary addition and shall be removed after #145 is fixed (adding a label for that)