### PR TITLE
Use shutil.move instead of os.rename in nopic mode

### DIFF
--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -1394,11 +1394,11 @@ def create_zim(
     cmd = "zimwriterfs "
     if nopic:
         tmpfile = tempfile.mkdtemp()
-        os.rename(
+        shutil.move(
             os.path.join(static_folder, "static", "images"),
             os.path.join(tmpfile, "images"),
         )
-        os.rename(
+        shutil.move(
             os.path.join(static_folder, "static", "identicon"),
             os.path.join(tmpfile, "identicon"),
         )
@@ -1418,11 +1418,11 @@ def create_zim(
     if exec_cmd(cmd) == 0:
         print("Successfuly created ZIM file at {}".format(zim_path))
         if nopic:
-            os.rename(
+            shutil.move(
                 os.path.join(tmpfile, "images"),
                 os.path.join(static_folder, "static", "images"),
             )
-            os.rename(
+            shutil.move(
                 os.path.join(tmpfile, "identicon"),
                 os.path.join(static_folder, "static", "identicon"),
             )
@@ -1430,11 +1430,11 @@ def create_zim(
         return True
     print("Unable to create ZIM file :(")
     if nopic:
-        os.rename(
+        shutil.move(
             os.path.join(tmpfile, "images"),
             os.path.join(static_folder, "static", "images"),
         )
-        os.rename(
+        shutil.move(
             os.path.join(tmpfile, "identicon"),
             os.path.join(static_folder, "static", "identicon"),
         )


### PR DESCRIPTION
Fixes #154 by using shutil.move instead of os.rename