### PR TITLE
Add timeout to HEAD request and rollback temporary changes

### DIFF
--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -894,20 +894,17 @@ def upload_to_cache(fpath, key, meta_tag, meta_val):
 
 
 def get_meta_from_url(url):
-    try:
-        for i in range(6):
+    def get_response_headers(url):
+        for attempt in range(5):
             try:
-                response_headers = requests.head(
-                    url=url, allow_redirects=True, timeout=20
-                ).headers
-                break
+                return requests.head(url=url, allow_redirects=True, timeout=30).headers
             except requests.exceptions.Timeout:
-                if i == 5:
-                    raise Exception("Max retries exceeded")
-                else:
-                    print(f"{url} > HEAD request timed out. Retrying...")
-    except Exception as e:
-        print(url + " > Problem while head request\n" + str(e) + "\n")
+                print(f"{url} > HEAD request timed out ({attempt})")
+        raise Exception("Max retries exceeded")
+    try:
+        response_headers = get_response_headers(url)
+    except Exception as exc:
+        print(f"{url} > Problem with head request\n{exc}\n")
         return None, None
     else:
         if response_headers.get("etag") is not None:


### PR DESCRIPTION
This shall fix #145 and rollback changes made in #155 and 96fbb557cf06bc03dff6970a579f2d27f601a6de 

The processes got stuck as some servers didn't close the connection (either with or without error). One suck example is an image that was being downloaded from the discord server.

This PR does the following -
- Add timeout to HEAD request in get_meta_from_url() (Timeout is 20s and 5 retries are allowed)
- Increase timeout for advdef to 60s and enable it
- Roll back changes in #155
