### PR TITLE
Create temp files if extension is wrong while optimizing

### DIFF
--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -1194,7 +1194,7 @@ def resize_one(path, ftype, nb_pix):
 
 def create_temporary_copy(path, suffix=None):
     path = pathlib.Path(path)
-    temp_path = tempfile.NamedTemporaryFile(dir=path.parent, suffix=suffix)
+    temp_path = tempfile.NamedTemporaryFile(dir=path.parent, suffix=suffix).name
     shutil.copyfile(path, temp_path)
     return temp_path
 

--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -1644,7 +1644,6 @@ def run():
         prepare(dump, os.path.abspath(os.path.dirname(__file__)) + "/")
 
     # Generate users !
-    # arguments["--nopic"],
     parser = make_parser()
     parser.setContentHandler(
         UsersRender(
@@ -1660,7 +1659,7 @@ def run():
             url,
             redirect_file,
             use_mathjax(domain),
-            True,
+            arguments["--nopic"],
             arguments["--no-userprofile"],
         )
     )

--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -1141,7 +1141,7 @@ def prepare(dump_path, bin_dir):
 
 
 def check_and_optimize(path, ftype):
-    if not path.endswith(f".{ftype}"):
+    if not (path.endswith(f".{ftype}") or (path.endswith(".jpg") and ftype == "jpeg")):
         print(
             f"{os.path.basename(path)} > Extension doesn't match detected file type. Creating temp copy with proper extension to optimize"
         )

--- a/sotoki/sotoki.py
+++ b/sotoki/sotoki.py
@@ -1193,11 +1193,9 @@ def resize_one(path, ftype, nb_pix):
 
 
 def create_temporary_copy(path, suffix=None):
-    fd, temp_path = tempfile.mkstemp(
-        dir=os.path.dirname(os.path.abspath(path)), suffix=suffix
-    )
-    os.close(fd)
-    shutil.copy2(path, temp_path)
+    path = pathlib.Path(path)
+    temp_path = tempfile.NamedTemporaryFile(dir=path.parent, suffix=suffix)
+    shutil.copyfile(path, temp_path)
     return temp_path
 
 


### PR DESCRIPTION
This fixes #152 by properly handling files if extension is different from the filetype detected.
This includes the following changes -
- download_image() - 
1. check_and_optimize is called instead of directly calling optimize_one()
check_and_optimize is a new function which checks the extension and the detected filetype and creates temp files if necessary
2. If detected filetype is not one which we can handle, we now raise an Exception
- image() - We now modify the image links only if download_image() succeeded
- create_temporary_copy() - Updated to create the temporary copy with a given suffix
- check_and_optimize() - This is a new function to handle extension and filetype checking, making temp file if necessary, calling optimize_one(), and copying optimized image from temporary copy to original path (if necessary).

PS - Sorry for being late. Just wanted to make sure everything works.
