### PR TITLE
Add --no-identicons option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * removed templates_mini
 * upgraded jdenticon to 2.2.0
 * single identicon behavior for normal and nopic mode
+* add `--no-identicons` option to skip downloading identicons and use only generated ones
 
 ### 1.3.1
 


### PR DESCRIPTION
This fixes #164 by adding a `--no-identicons` option to create smaller ZIMs by skipping download of identicons and using only the autogenerated ones.