### PR TITLE
Add pylibzim support and some small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * upgraded jdenticon to 2.2.0
 * single identicon behavior for normal and nopic mode
 * add `--no-identicons` option to skip downloading identicons and use only generated ones
+* use pylibzim to create ZIM file
+* properly handle root-relative links
+* removed zipping HTML files on disk and use of --inflateHTML zimwriterfs option
 
 ### 1.3.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
 FROM python:3.8
 
-# add zimwriterfs
-RUN wget http://download.openzim.org/release/zimwriterfs/zimwriterfs_linux-x86_64-1.3.8.tar.gz
-RUN tar -C /usr/bin --strip-components 1 -xf zimwriterfs_linux-x86_64-1.3.8.tar.gz
-RUN rm -f zimwriterfs_linux-x86_64-1.3.8.tar.gz
-RUN chmod +x /usr/bin/zimwriterfs
-RUN zimwriterfs --version
-
 # Install necessary packages
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends advancecomp libxml2-dev libxslt1-dev libbz2-dev p7zip-full gif2apng imagemagick libjpeg-dev libpng-dev locales && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,10 @@ lxml==4.5.0
 MarkupSafe==1.1.1
 docopt==0.6.2
 python-slugify==4.0.0
-beautifulsoup4==4.9.0
-python-magic==0.4.15
+beautifulsoup4==4.9.1
 mistune>=2.0.0a3
 Pillow==7.1.1
 kiwixstorage>=0.2,<1.0
 pif==0.8.2
-zimscraperlib>=1.1.0,<1.2
+zimscraperlib>=1.2.1,<1.3
 

--- a/sotoki/templates/post.mixin.html
+++ b/sotoki/templates/post.mixin.html
@@ -42,7 +42,7 @@
                 {% if post["OwnerUserId"]["Path"] %}<a class="profile" href="../user/{{ post["OwnerUserId"]["Path"] }}.html"> {% endif %}
                 {% if post["OwnerUserId"]["Id"] %}
                 <!-- object data not rewritten by zimwriterfs -->
-                <object class="genprofilepic" width="65" height="65" data="../../I/static/identicon/{{ post["OwnerUserId"]["Id"] }}.png" type="image/png">
+                <object class="genprofilepic" width="65" height="65" data="{{ rooturl }}static/identicon/{{ post["OwnerUserId"]["Id"] }}.png" type="image/png">
                   <svg class="genprofilepic" width="65" height="65" data-jdenticon-value="{{ post["OwnerUserId"]["Id"] }}"></svg>
                 </object>
                 {% endif %}


### PR DESCRIPTION
This replaces `zimwriterfs` based ZIM creation with `pylibzim` based ZIM creation using `make_zim_file()` from `zimscraperlib`
This has the following changes -
- removed check for `zimwriterfs`
- use make_zim_file() from `zimscraperlib` to create ZIM
- remove `zimwriterfs` from Dockerfile
- handle root-relative links properly (wasn't handled properly before) - In `interne_link()`
- disable deflating the HTMLs before creating ZIMs
- fix the link to identicons in post template - (Had the namespace already and hence, rewriting failed in `zimscraperlib`
- use zimwriterfs.filesystem for filetype identification (the previous magic package had conflicts with the one we use in scraperlib as they have the same package name)