### PR TITLE
Fix user identicon path in templates

### DIFF
--- a/sotoki/templates/post.mixin.html
+++ b/sotoki/templates/post.mixin.html
@@ -41,8 +41,7 @@
           <div> 
                 {% if post["OwnerUserId"]["Path"] %}<a class="profile" href="../user/{{ post["OwnerUserId"]["Path"] }}.html"> {% endif %}
                 {% if post["OwnerUserId"]["Id"] %}
-                <!-- object data not rewritten by zimwriterfs -->
-                <object class="genprofilepic" width="65" height="65" data="{{ rooturl }}static/identicon/{{ post["OwnerUserId"]["Id"] }}.png" type="image/png">
+                <object class="genprofilepic" width="65" height="65" data="../static/identicon/{{ post["OwnerUserId"]["Id"] }}.png" type="image/png">
                   <svg class="genprofilepic" width="65" height="65" data-jdenticon-value="{{ post["OwnerUserId"]["Id"] }}"></svg>
                 </object>
                 {% endif %}
@@ -69,7 +68,7 @@
               <span class="score {{ comment["Score"] | scale }}">{{ comment["Score"] }}</span>
             {% endif %}
             <span class="text">{{ comment["Text"] | safe }}</span> – {% if comment["Path"] %}<a href="{{ rooturl }}/user/{{ comment["Path"] }}.html">{% endif %}{{ comment["UserDisplayName"] }} {% if comment["Path"] %}</a>{% endif %} – <span class="date" title="{{ comment["CreationDate"] }}">{{ comment["CreationDate"] }}</span>
-            </p>
+          </p>
         </div>
       {% endfor %}
     </div>

--- a/sotoki/templates/question.html
+++ b/sotoki/templates/question.html
@@ -54,7 +54,7 @@
             {% endfor %}
            </ul>
         </div>
-    {% endif %}
+      {% endif %}
     </div>
   </div>
   <script src="{{ rooturl }}/static/main.js"></script>

--- a/sotoki/templates/user.html
+++ b/sotoki/templates/user.html
@@ -10,9 +10,8 @@
   </div>
   <div class="row">
     <div class="col-md-3">
-      <div> 
-        <!-- object data not rewritten by zimwriterfs -->
-        <object class="genprofilepic" data="../../I/static/identicon/{{ user["Id"] }}.png" style="width:164px; height:164px;" type="image/png">
+      <div>
+        <object class="genprofilepic" data="../static/identicon/{{ user["Id"] }}.png" style="width:164px; height:164px;" type="image/png">
           <svg width="164" height="164" data-jdenticon-value="{{ user["Id"] }}"></svg>
         </object>
       </div> 


### PR DESCRIPTION
This fixes small error in path of identicons and removes the comment stating that zimwriterfs doesn't write object data links.