### PR TITLE
Fix some dead links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * use pylibzim to create ZIM file
 * properly handle root-relative links
 * removed zipping HTML files on disk and use of --inflateHTML zimwriterfs option
+* fix invalid tag internal links
+* user profile links now redirect to online version if `--nouserprofile` option is passed
 
 ### 1.3.1
 


### PR DESCRIPTION
Addresses #161. This does the following -
- Fix tag links
- The user profile links now redirect to online instances if `--nouserprofile` option is passed
- The variable `static_folder` is replaced with `output_dir` as it was changed before.

This still cannot two links, one of them being a user comment with a answer ID that doesn't exist and the other one being a tag abc* type link which is resolved into abc-a, abcb, abcx .. etc. For this we need to write a redirect or somehow need to store such links till the process of writing tag HTMLs.