### PR TITLE
Added WebP Polyfill

### DIFF
--- a/src/sotoki/dependencies.py
+++ b/src/sotoki/dependencies.py
@@ -50,6 +50,20 @@ ASSETS = [
         "static/js/mobile.en.js",
         "https://cdn.sstatic.net/Js/mobile.en.js",
     ),
+    # WepP Hero polyfill
+    (
+        "static/js/webp-hero.polyfill.js",
+        "https://unpkg.com/webp-hero@0.0.0-dev.27/dist-cjs/polyfills.js",
+    ),
+    (
+        "static/js/webp-hero.bundle.js",
+        "https://unpkg.com/webp-hero@0.0.0-dev.27/dist-cjs/webp-hero.bundle.js",
+    ),
+    (
+        "static/js/webp-handler.js",
+        "https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/"
+        "raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js",
+    ),
     # MathJax dependencies. SE uses v2.7.5 ATM
     (
         "static/js/MathJax.js",
@@ -105,6 +119,11 @@ ASSETS = [
         "static/js/jax/output/HTML-CSS/fonts/STIX/General/Regular/GreekItalic.js",
         "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/"
         "jax/output/HTML-CSS/fonts/STIX/General/Regular/GreekItalic.js?V=2.7.5",
+    ),
+    (
+        "static/js/jax/output/HTML-CSS/fonts/TeX/fontdata.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/"
+        "jax/output/HTML-CSS/fonts/TeX/fontdata.js?V=2.7.5",
     ),
     # following assets were manualy extracted from primary.css and secondary.css
     # those seem to be similar in all sites.

--- a/src/sotoki/templates/base.html
+++ b/src/sotoki/templates/base.html
@@ -8,10 +8,6 @@
         <link rel="apple-touch-icon" href="apple-touch-icon.png" />
         <link rel="image_src" href="apple-touch-icon.png" />
         <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0" />
-
-        <script src="static/js/jquery.min.js"></script>
-        <script src="static/js/stub.en.js?v=784a450186a7"></script>
-
         <link rel="stylesheet" type="text/css" href="static/css/stacks.min.css" />
         <link id="primary_css" rel="stylesheet" type="text/css" href="static/css/primary.css" />
         <link id="secondary_css" rel="stylesheet" type="text/css" href="static/css/secondary.css" />
@@ -29,6 +25,52 @@
             .about-text { padding-bottom: 16px; padding-top: 16px; }
         </style>
         <script type="text/javascript" src="static/js/jdenticon.min.js" async></script>
+        <script type="text/javascript" src="static/js/webp-hero.polyfill.js"></script>
+        <script type="text/javascript" src="static/js/webp-hero.bundle.js"></script>
+        <script type="text/javascript" src="static/js/webp-handler.js"></script>
+        <script type="text/javascript">
+            /*
+             * replace an <img/> node with a jdidenticon <svg />
+             * Uses it's parent .innerHTML so img should be wrapped.
+             * @param img: either an HTMLImageElement or an Error event
+             */
+            function replaceWithJdenticon(img) {
+                if (!(img instanceof HTMLImageElement)) {
+                    img = img.srcElement;
+                }
+                if (img.getAttribute('data-jdenticon-value') || img.getAttribute('data-jdenticon-hash')) {
+                    img.parentNode.innerHTML = jdenticon.toSvg(img.getAttribute('data-jdenticon-value') || img.getAttribute('data-jdenticon-hash'), img.width || img.getAttribute("data-jdenticon-width"));
+                }
+            }
+            var webp_handler = new WebPHandler({
+                on_error: replaceWithJdenticon,
+                scripts_urls: ["static/js/webp-hero.polyfill.js", "static/js/webp-hero.bundle.js"],
+            });
+
+            /*
+             * manually set (in-templates) on all <img /> nodes so that any error loading
+             * it by the browser calls it. Used to trigger polyfill and jdenticon fallback
+             * /!\ requires WebPHandler to be ready _before_ the browser attempts to 
+             * load any image in the page. WebP Hero scripts should thus be included
+             * syncrhonously before this */
+            function onImageLoadingError(img) {
+                if (img === undefined)
+                    return;
+
+                // only use polyfill if browser lacks Webp supports and wasn't already polyfied
+                // polyfill replaces url with data URI
+                if (!webp_handler.supports_webp && img.src.length > 0 && img.src.substr(0, 5) != "data:") {
+                    webp_handler.polyfillImage(img);
+                    return;
+                }
+
+                // defaults to rendering as Jdenticon
+                replaceWithJdenticon(img);
+            }
+        </script>
+        <script src="static/js/moment.min.js"></script>
+        <script src="static/js/jquery.min.js"></script>
+        <script src="static/js/stub.en.js?v=784a450186a7"></script>
         <script type="text/x-mathjax-config">
                 MathJax.Hub.Config({"HTML-CSS": { preferredFont: "TeX", availableFonts: ["STIX","TeX"], linebreaks: { automatic:true }, EqnChunk: (MathJax.Hub.Browser.isMobile ? 10 : 50) },
                     tex2jax: { inlineMath: [ ["$", "$"], ["\\\\(","\\\\)"] ], displayMath: [ ["$$","$$"], ["\\[", "\\]"] ], processEscapes: true, ignoreClass: "tex2jax_ignore|dno" },
@@ -44,7 +86,6 @@
         </script>
         <script src="static/js/MathJax.js?config=TeX-AMS_HTML-full"></script>
         <script src="static/js/highlightjs-loader.en.js?v=17552072fdc0"></script>
-        <script src="static/js/moment.min.js"></script>
     </head>
     <body class="{{ body_class}} unified-theme">
         <div class="topbar mobile-only">
@@ -114,6 +155,7 @@
         </div>
         <script src="static/js/stack-icons.js"></script>
         <script>
+            /* replace <time class="fromnow" /> with human delta between `datetime` attr and now */
             document.addEventListener('DOMContentLoaded', function(){
                 var time_elements = document.querySelectorAll("time.fromnow");
                 for (i=0; i<time_elements.length; i++) {

--- a/src/sotoki/templates/user.html
+++ b/src/sotoki/templates/user.html
@@ -5,9 +5,7 @@
         <div class="-top">
             <a href="users/{{ Id }}/{{ slug }}" class="-avatar">
                 <div class="gravatar-wrapper-48">
-                    <object class="bar-sm" data="images/user/{{ Id }}" type="image/webp" width="48" height="48">
-                        <svg width="48" height="48" data-jdenticon-value="{{ DisplayName }}"></svg>
-                    </object>
+                    <img class="bar-sm" src="users/profiles/{{ Id }}.webp" width="48" height="48" data-jdenticon-value="{{ DisplayName }}" onerror="javascript:onImageLoadingError.call(this);" />
                 </div>
             </a>
             <div class="-details">
@@ -39,9 +37,7 @@
                         <div class="avatar mt16 mx-auto overflow-hidden">
                             <a class="d-block" href="users/{{ Id }}">
                                 <div class="gravatar-wrapper-164">
-                                    <object class="bar-sm avatar-user" data="images/user/{{ Id }}" type="image/webp" width="164" height="164">
-                                        <svg width="164" height="164" data-jdenticon-value="{{ DisplayName }}"></svg>
-                                    </object>
+                                    <img class="bar-sm" src="users/profiles/{{ Id }}.webp" width="164" height="164" data-jdenticon-value="{{ DisplayName }}" onerror="javascript:onImageLoadingError(this);" />
                                 </div>
                             </a>
                         </div>

--- a/src/sotoki/templates/user_card.html
+++ b/src/sotoki/templates/user_card.html
@@ -9,9 +9,7 @@
 <div class="s-user-card s-user-card{% if highlighted %}__highlighted{% endif %}">
     <time class="s-user-card--time{% if action_from_now %} fromnow{% endif %}" datetime="{{ action_time }}">{{ action_time|datetime }}</time>
     <a href="users/{{ user.id }}/{{ user.slug }}" class="s-avatar s-avatar__32 s-user-card--avatar">
-        <object class="s-avatar--image" data="images/user/{{ user.id }}" type="image/webp">
-          <svg width="32" height="32" data-jdenticon-value="{{ user.name }}"></svg>
-        </object>
+        <img class="s-avatar--image" src="users/profiles/{{ user.id }}.webp" data-jdenticon-width="32" data-jdenticon-height="32" data-jdenticon-value="{{ user.name }}" onerror="onImageLoadingError(this);" />
     </a>
     <div class="s-user-card--info">
         <a href="users/{{ user.id }}/{{ user.slug }}" class="s-user-card--link">{{ user.name }}</a>

--- a/src/sotoki/templates/users.html
+++ b/src/sotoki/templates/users.html
@@ -12,9 +12,7 @@
                         <div class="user-gravatar48">
                             <a href="users/{{ user.id }}/{{ user.slug }}">
                                 <div class="gravatar-wrapper-48">
-                                    <object class="bar-sm" data="images/user/{{ id }}" type="image/webp" width="48" height="48">
-                                        <svg width="48" height="48" data-jdenticon-value="{{ user.name }}"></svg>
-                                    </object>
+                                    <img class="bar-sm" src="users/profiles/{{ user.id }}.webp" width="48" height="48" data-jdenticon-value="{{ user.name }}" onerror="onImageLoadingError(this);" />
                                 </div>
                             </a>
                         </div>

--- a/src/sotoki/users.py
+++ b/src/sotoki/users.py
@@ -52,7 +52,7 @@ class UsersWalker(Walker):
                 if profile_url:
                     self.imager.defer(
                         url=profile_url,
-                        path=f"images/user/{self.user['Id']}",
+                        path=f"users/profiles/{self.user['Id']}.webp",
                         is_profile=True,
                     )
 

--- a/src/sotoki/utils/html.py
+++ b/src/sotoki/utils/html.py
@@ -225,6 +225,7 @@ class Rewriter(GlobalMixin):
                 del img["src"]
             # process all images
             else:
+                img["onerror"] = "onImageLoadingError(this);"
                 img["src"] = self.imager.defer(img["src"], is_profile=False)
 
     # def censor_words_as_string(self, soup) -> str:

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -228,7 +228,7 @@ class Imager:
         # skip processing if we already processed it or have it in pipe
         digest = self.get_digest_for(url.geturl())
         if path is None:
-            path = f"images/{digest}"
+            path = f"images/{digest}.webp"
 
         if digest in self.handled:
             logger.debug(f"URL `{url.geturl()}` already processed.")


### PR DESCRIPTION
Added WebP Hero polyfill on images:
- images now named ending with `.webp` in ZIM
- polyfill scripts included always (350KB) in page
- polyfill applied on loading error with a fallback to jdenticon
- regular loading + jdenticon fallback for browsers with WebP support
- using <img /> elements instead of <object />
- jdenticon dynamically replacing failing <img /> (requires JS)