### PR TITLE
Added CI build for test scraper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  build-and-run:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: docker build . -t sotoki
+      - run: mkdir -p output
+      - name: run for beer meta
+        run: docker run -v $(pwd)/output:/output sotoki sotoki --domain "beer.meta.stackexchange.com" --threads 20 --output /output/ --zim-file beer_meta.zim --mirror "https://org-kiwix-stackexchange.s3.us-west-1.wasabisys.com" --redis-url "file:///var/run/redis.sock" --debug
+      - run: ls -alh $(pwd)/output
+      - name: pull zim-tools
+        run: docker pull openzim/zim-tools:latest
+      - name: run zimcheck
+        # not using --redundant as user profile pics can be duplicates
+        # not using --url_internal as zimcheck doesn't account for <base/> https://github.com/openzim/zim-tools/issues/250
+        # not using --url_external as zimcheck doesn't account for <blockquote />, <script />, etc. https://github.com/openzim/zim-tools/issues/149
+        run: docker run -v $(pwd)/output:/data:ro openzim/zim-tools:latest zimcheck --empty --checksum --integrity --metadata --favicon --main --mime --details /data/beer_meta.zim


### PR DESCRIPTION
- Builds the docker image
- Runs the scraper using docker image
- Launched zimcheck --empty --checksum --integrity --metadata --favicon --main --mime --details on resulting zim

Currently fails due to https://github.com/openzim/zim-tools/issues/249