### PR TITLE
Implemented progress reporting

### DIFF
--- a/src/sotoki/constants.py
+++ b/src/sotoki/constants.py
@@ -108,7 +108,7 @@ class Sotoconf:
     debug: Optional[bool] = False
     prepare_only: Optional[bool] = False
     keep_intermediate_files: Optional[bool] = False
-    statsFilename: Optional[str] = None
+    stats_filename: Optional[str] = None
     #
     build_dir_is_tmp_dir: Optional[bool] = False
     dump_date: Optional[datetime.date] = datetime.date.today()
@@ -153,6 +153,9 @@ class Sotoconf:
             self.build_dir = pathlib.Path(
                 tempfile.mkdtemp(prefix=f"{self.domain}_", dir=self.tmp_dir)
             )
+        if self.stats_filename:
+            self.stats_filename = pathlib.Path(self.stats_filename).expanduser()
+        self.stats_filename.parent.mkdir(parents=True, exist_ok=True)
 
         self.redis_url = urllib.parse.urlparse(self._redis_url)
         if self.redis_url and self.redis_url.scheme not in ("unix", "redis"):

--- a/src/sotoki/entrypoint.py
+++ b/src/sotoki/entrypoint.py
@@ -227,7 +227,11 @@ def main():
         "--debug", help="Enable verbose output", action="store_true", default=False
     )
 
-    advanced.add_argument("--statsFilename")
+    advanced.add_argument(
+        "--stats-filename",
+        help="Path to store the progress JSON file to.",
+        dest="stats_filename",
+    )
 
     advanced.add_argument("--prepare-only", action="store_true", dest="prepare_only")
 

--- a/src/sotoki/posts.py
+++ b/src/sotoki/posts.py
@@ -98,6 +98,8 @@ class PostFirstPasser(Generator):
 
         self.database.record_question(post=item)
 
+        self.progresser.update(incr=True)
+
 
 class PostsWalker(Walker):
     """posts_complete SAX parser
@@ -240,6 +242,8 @@ class PostGenerator(Generator):
                     path=f'a/{answer["Id"]}',
                     target_path=path,
                 )
+
+        self.progresser.update(incr=True)
 
     def generate_questions_page(self):
         paginator = SortedSetPaginator(

--- a/src/sotoki/tags.py
+++ b/src/sotoki/tags.py
@@ -41,6 +41,7 @@ class TagFinder(Generator):
 
         tag["Count"] = int(tag["Count"])
         self.database.record_tag(tag)
+        self.progresser.update(incr=True)
 
 
 class TagsExcerptWalker(Walker):
@@ -64,6 +65,7 @@ class TagExcerptDescriptionRecorder(Generator):
             self.database.record_tag_detail(
                 name=tag_name, field=self.field, content=item.get("Body")
             )
+        self.progresser.update(incr=True)
 
 
 class TagExcerptRecorder(TagExcerptDescriptionRecorder):
@@ -110,6 +112,7 @@ class TagGenerator(Generator):
                     path=f"questions/tagged/{tag_id}",
                     target_path=f"questions/tagged/{tag_name}_page=1",
                 )
+            self.progresser.update(incr=True)
 
         # create paginated pages for tags
         paginator = SortedSetPaginator(self.database.tags_key(), per_page=36)

--- a/src/sotoki/users.py
+++ b/src/sotoki/users.py
@@ -103,6 +103,8 @@ class UserGenerator(Generator):
                 mimetype="text/html",
             )
 
+        self.progresser.update(incr=True)
+
     def generate_users_page(self):
         paginator = SortedSetPaginator(
             self.database.users_key(), per_page=36, at_most=3600

--- a/src/sotoki/utils/__init__.py
+++ b/src/sotoki/utils/__init__.py
@@ -42,3 +42,7 @@ class GlobalMixin:
     @property
     def rewriter(self):
         return Global.rewriter
+
+    @property
+    def progresser(self):
+        return Global.progresser

--- a/src/sotoki/utils/database.py
+++ b/src/sotoki/utils/database.py
@@ -9,9 +9,9 @@
 """
 
 import json
+import time
 import pathlib
 import threading
-import urllib.parse
 from typing import Union, Iterator, Tuple
 
 import redis
@@ -299,7 +299,6 @@ class UsersDatabaseMixin:
         id, name, rep, nb_gold, nb_silver, nb_bronze"""
         user = self.conn.get(self.user_key(user_id))
         if not user:
-            logger.warning(f"get_user_full('{user_id}') is None")
             return None
         user = json.loads(user)
         return {
@@ -389,8 +388,8 @@ class PostsDatabaseMixin:
 
         # TODO: just storing name instead of id is not safe. a deleted user could
         # have a name such as "3200" and that would be rendered as User#3200
-        if not post.get("OwnerUserId"):
-            logger.debug(f"No OwnerUserId for {post['Id']}")
+        # if not post.get("OwnerUserId"):
+
         # store question details
         self.pipe.setnx(
             self.question_key(post["Id"]),
@@ -542,6 +541,7 @@ class RedisDatabase(
 
         # make sure we've commited pipes on all thread-specific pipelines
         if done:
+            time.sleep(2)  # prevent last-thread created while we iterate on mini domain
             for pipe in self.pipes.values():
                 pipe.execute()
 

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -120,7 +120,6 @@ class Imager:
             if provider.matches(url, for_profile=for_profile):
                 return provider.get_source_url(url, for_profile=for_profile)
         # no provider
-        logger.warning(f"No provider for {url.geturl()}")
         return url
 
     def get_image_data(self, url: str, **resize_args: dict) -> io.BytesIO:
@@ -218,8 +217,7 @@ class Imager:
     def once_done(self, future):
         """default callback for single image processing"""
         self.nb_done += 1
-        logger.debug(f"Imager progress: {self.nb_done}/{self.nb_requested}")
-        return
+        Global.progresser.update()
 
     def process_image(self, url: str, path, is_profile: bool = False) -> str:
         """download image from url or S3 and add to Zim at path. Upload if req."""

--- a/src/sotoki/utils/progress.py
+++ b/src/sotoki/utils/progress.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4 nu
+
+import json
+import datetime
+from typing import Union
+from collections import OrderedDict
+
+from ..constants import getLogger
+from ..utils import GlobalMixin
+
+logger = getLogger()
+
+
+class Progresser(GlobalMixin):
+
+    PREPARATION_STEP = "prep"
+    TAGS_METADATA_STEP = "tags_meta"
+    QUESTIONS_METADATA_STEP = "questions_meta"
+    USERS_STEP = "users"
+    QUESTIONS_STEP = "questions"
+    TAGS_STEP = "tags"
+    LISTS_STEP = "lists"
+    IMAGES_STEP = "images"
+
+    # steps names and weights
+    STEPS = OrderedDict(
+        [
+            (PREPARATION_STEP, 5),
+            (TAGS_METADATA_STEP, 2),
+            (QUESTIONS_METADATA_STEP, 10),
+            (USERS_STEP, 5),
+            (QUESTIONS_STEP, 30),
+            (TAGS_STEP, 2),
+            (LISTS_STEP, 1),
+        ]
+    )
+
+    # weight of images processing within the whole scraping process
+    IMAGES_WEIGHT = 60
+
+    PRINT_EVERY_UPDATES = 10000
+    PRINT_EVERY_SECONDS = 300
+
+    def __init__(self):
+        # keep track of current step's data
+        self.current_step = self.PREPARATION_STEP
+        self.current_step_index = 0
+        self.current_step_total = 0
+        self.current_step_progress = 0
+        self.current_step_updates = 0
+
+        # computed sum of all previous steps
+        self.previous_step_weight = 0
+
+        # compute respective weights of all steps
+        # to fix weights from constants
+        total_weight = self.IMAGES_WEIGHT + sum(self.STEPS.values())
+        self.weights = {key: value / total_weight for key, value in self.STEPS.items()}
+        self.weights[self.IMAGES_STEP] = (
+            self.IMAGES_WEIGHT / total_weight if not self.conf.without_images else 0
+        )
+
+        self.last_print_on = datetime.datetime.now()
+
+    def update_json(self):
+        """Update JSON progress file if such a file was requested"""
+        if not self.conf.stats_filename:
+            return
+        with open(self.conf.stats_filename, "w") as fh:
+            json.dump(
+                {"done": round(self.overall_progress * 100, 2), "total": 100},
+                fh,
+            )
+
+    def update(
+        self, nb_done: int = None, nb_total: int = None, incr: Union[int, bool] = None
+    ):
+        """update current step's progress
+
+        set nb_done or nb_total to an arbitrary value
+        or increment nb_done by any number"""
+
+        # record we received an update
+        self.current_step_updates += 1
+
+        if nb_done is not None:
+            self.current_step_progress = nb_done
+        elif incr is not None:
+            self.current_step_progress += int(incr)
+        if nb_total is not None:
+            self.current_step_total = nb_total
+
+        self.update_json()
+
+        self.print_maybe()
+
+    def print(self):
+        """log current progress state"""
+        msg = (
+            f"PROGRESS: {self.overall_progress * 100:.1f}% – "
+            f"{self.current_step.title()} "
+            f"Step ({self.current_step_index + 1}/{len(self.STEPS)})"
+        )
+
+        if self.images_progress:
+            msg += f" Images progress: {self.images_progress * 100:.0f}%"
+        logger.info(msg)
+        self.last_print_on = datetime.datetime.now()
+
+    def print_maybe(self):
+        if (
+            self.current_step_updates % self.PRINT_EVERY_UPDATES == 0
+            or self.last_print_on + datetime.timedelta(seconds=self.PRINT_EVERY_SECONDS)
+            < datetime.datetime.now()
+        ):
+            self.print()
+
+    def start(self, step: str, nb_total: int = 0):
+        """start a new step. Considers previous steps as completed.
+
+        nb_total: set total for this step"""
+        if step not in self.STEPS.keys():
+            raise KeyError(f"Step `{step}` is not a valid step")
+
+        step_index = list(self.STEPS.keys()).index(step)
+
+        # compute done steps weight
+        self.previous_step_weight = sum(
+            [
+                self.weights.get(s)
+                for i, s in enumerate(self.STEPS.keys())
+                if i < step_index
+            ]
+        )
+
+        self.current_step = step
+        self.current_step_index = step_index
+        self.current_step_total = nb_total
+        self.current_step_progress = 0
+        self.current_step_updates = 0
+        self.print()
+
+    def weight_for(self, step: str) -> float:
+        """weight of a step within total"""
+        return self.weights.get(step)
+
+    @property
+    def step_progress(self) -> float:
+        """progress of current step (0-1)"""
+        try:
+            return min([self.current_step_progress / self.current_step_total, 1])
+        except ZeroDivisionError:
+            return 1
+
+    @property
+    def images_progress(self) -> float:
+        """progress of images step (0-1)"""
+        if getattr(self.imager, "nb_requested", 0) == 0:
+            return 0
+        try:
+            return min(
+                [
+                    getattr(self.imager, "nb_done", 0)
+                    / getattr(self.imager, "nb_requested", 0),
+                    1,
+                ]
+            )
+        except ZeroDivisionError:
+            return 1
+
+    @property
+    def overall_progress(self) -> float:
+        """scraper progress (0-1)"""
+        return (
+            self.previous_step_weight
+            + (self.images_progress * self.weight_for(self.IMAGES_STEP))
+            + (self.step_progress * self.weight_for(self.current_step))
+        )


### PR DESCRIPTION
First version of Progress reporter:

- Displays progress on log (INFO level)
- Dumps computed progress to JSON file if using --stats-filename (zimfarm)

Progress is printing on every 10K updates or every 5mn if there hasn't been that
many updates since.

Progress is split accross 7 steps each being assigned an arbitrary weight:

PREPARATION_STEP: 5
TAGS_METADATA_STEP: 2
QUESTIONS_METADATA_STEP: 10
USERS_STEP: 5
QUESTIONS_STEP: 30
TAGS_STEP: 2
LISTS_STEP: 1

In addition, we account Image “processing” a weight of 60. This processing can be
either downloading source, convertion, optimization, upload, add to zim or just
download-from-s3, add to zim.

Those weights are __arbitrary__ and will be updated once we have enough data to pick
better values

Every question/user/tag processed (parsed, stored, added to zim) increments the progress
and we know the expected number before hand so progress increases linearily.

As for images, we don't know the expected number of files before hand and are thus
incrementing this number upon discovery. I suppose it might make the progress look
a bit stale in a single thread scenario where images are processed as discovered.

Fixed #202 