### PR TITLE
User profile now responsive

### DIFF
--- a/src/sotoki/assets/static/css/sotoki.css
+++ b/src/sotoki/assets/static/css/sotoki.css
@@ -1,0 +1,241 @@
+/* we don't include SE's topbar */
+body {
+     padding-top: 0;
+}
+/* outbound array icon for all external links */
+ a.external-link {
+    /* overriden in template to account for relative path */
+     background-image: url('static/img/external-link-ltr-icon.svg');
+     background-position: center right;
+     background-repeat: no-repeat;
+     padding-right: 13px;
+}
+/* kiwix-serve hack so we don't break the magnifier icon */
+ .kiwix_searchform input.ui-autocomplete-input {
+     margin-top: 0;
+     margin-bottom: 0;
+}
+ .kiwix_searchform {
+     font-size: 14px;
+}
+/* Small width screen adaptations (mobile) */
+ .mobile-only {
+     display: none;
+}
+ @media screen and (max-width: 640px) {
+     .mobile-only {
+         display: block;
+    }
+     .desktop-only {
+         display: none;
+    }
+     .post-layout--left, .post-layout--left.votecell {
+         padding-right: 0;
+    }
+     html.html__responsive:not(.html__unpinned-leftnav) #content {
+         padding-left: 8px;
+         padding-right: 8px;
+    }
+     html.html__responsive:not(.html__unpinned-leftnav) .question-summary {
+         padding-left: 0 !important;
+         padding-right: 0 !important;
+    }
+     body.tagged-questions-page #questions.pl24 .mln24 {
+         margin-left: 0 !important;
+    }
+    /* User profile: display all blocks as rows */
+     body.user-page .profile-box {
+         display: block !important;
+    }
+     body.user-page .reputation-box, .metadata-box {
+         margin: auto;
+         flex-shrink: unset 
+    }
+     body.user-page .metadata-box {
+         max-width: unset;
+    }
+     body.user-page .profile-user--name {
+         text-align: center;
+    }
+     body.user-page .flex-spacer {
+         display: none;
+         flex-grow: unset;
+    }
+}
+/* Top bar design copied from SE's mobile.css https://cdn.sstatic.net/Sites/alcoholmeta/mobile.css */
+ .topbar{
+     background:#0c0d0e;
+     height:44px 
+}
+ .topbar .topbar-icon,.topbar .date-group-toggle,.topbar .icon-help>.triangle{
+     background-color:transparent;
+     background-repeat:no-repeat 
+}
+ .topbar .network-items{
+     display:-webkit-flex;
+     display:flex;
+     -webkit-align-items:stretch;
+     align-items:stretch;
+     height:44px 
+}
+ .topbar .site-name{
+     display:-webkit-flex;
+     display:flex;
+     -webkit-align-items:center;
+     align-items:center;
+     overflow:hidden 
+}
+ .topbar .site-name a{
+     color:#fff;
+     display:block;
+     text-overflow:ellipsis;
+     overflow:hidden;
+     white-space:nowrap;
+     width:100% 
+}
+ .topbar .site-name small{
+     color:#9199a1;
+     font-size:11px;
+     text-transform:uppercase;
+     display:block 
+}
+ .topbar .-actions{
+     display:-webkit-flex;
+     display:flex;
+     margin-left:auto 
+}
+ .topbar .topbar-icon{
+     display:-webkit-flex;
+     display:flex;
+     -webkit-align-items:center;
+     align-items:center;
+     justify-content:center;
+     height:44px;
+     margin-bottom:0;
+     padding:0 10px;
+     color:#9199a1 
+}
+ .topbar .topbar-icon-on{
+     background-color:#eff0f1 
+}
+ .topbar .icon-inbox .unread-count{
+     background-color:#d1383d 
+}
+ .topbar .icon-achievements .unread-count{
+     background-color:#33A030 
+}
+ .topbar ._danger-indicator:after{
+     content:'';
+     width:10px;
+     height:10px;
+     border-radius:50%;
+     position:absolute;
+     box-sizing:content-box;
+     right:2px;
+     top:10px;
+     background:#d1383d;
+     z-index:2;
+     border:2px solid #0c0d0e;
+     transition:top cubic-bezier(.165, .84, .44, 1) .15s 
+}
+ .topbar ._danger-indicator.topbar-icon-on:after{
+     border:2px solid #eff0f1 
+}
+ .topbar .icon-site-switcher-bubble{
+     width:46px;
+     background-position:20px 11px;
+     background-repeat:no-repeat;
+     background-size:auto 24px;
+     background-image:url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMzhweCIgaGVpZ2h0PSI0OHB4IiB2aWV3Qm94PSIwIDAgMzggNDgiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+ICAgICAgICA8dGl0bGU+bG9nbzwvdGl0bGU+ICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiAgICA8ZGVmcz48L2RlZnM+ICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPiAgICAgICAgPGcgaWQ9ImxvZ28iPiAgICAgICAgICAgIDxwYXRoIGQ9Ik0zOC4wMDAwMDEyLDIxIEwzOC4wMDAwMDEyLDI5IEwtMS4xOTIwOTE3M2UtMDksMjkgTC0xLjE5MjA5MTczZS0wOSwyMSBMMzguMDAwMDAxMiwyMSBaIiBpZD0iU2hhcGUiIGZpbGw9IiMzODYzQTAiPjwvcGF0aD4gICAgICAgICAgICA8cGF0aCBkPSJNMzguMDAwMDAxMiwxMC45OTEgTDM4LjAwMDAwMTIsMTguOTk5OTk5OCBMLTEuMTkyMDkxNzNlLTA5LDE4Ljk5OTk5OTggTC0xLjE5MjA5MTczZS0wOSwxMC45OTEgTDM4LjAwMDAwMTIsMTAuOTkxIFoiIGlkPSJTaGFwZSIgZmlsbD0iIzRDOTdDNiI+PC9wYXRoPiAgICAgICAgICAgIDxwYXRoIGQ9Ik01Ljk5OTk5OTk3LDYuNjc1NzIwNDJlLTA5IEMxLjk5OTk5OTk3LDYuNjc1NzIwNDJlLTA5IC0xLjgxMTk4MTMyZS0wOCwzLjAxNzAwMDAxIC0xLjgxMTk4MTMyZS0wOCw2LjUwMDAwMDAxIEwtMi44NjEwMjMwNmUtMDgsOS4wMDAwMDAwMSBMMzgsOS4wMDAwMDAwMSBMMzgsNi41MDAwMDAwMSBDMzgsMy4wMTYwMDAwMSAzNiw2LjY3NTcyMDQyZS0wOSAzMiw2LjY3NTcyMDQyZS0wOSBMNS45OTk5OTk5Nyw2LjY3NTcyMDQyZS0wOSBaIiBpZD0iU2hhcGUiIGZpbGw9IiM5MEQyRTgiPjwvcGF0aD4gICAgICAgICAgICA8cGF0aCBkPSJNMC4wMDEwMDAwMDA4MywzMy4wNTIgQzAuMDAxMDAwMDAwODMsMzYuNTM2IDIuNjU2LDM5IDYsMzkgTDIxLDM5IEwyMSw0OCBMMzAsMzkgTDMxLjUsMzkgQzM0Ljg0NywzOSAzOCwzNi45ODMgMzgsMzMuNSBMMzgsMzEgTDguMzQ0NjEzODllLTEwLDMxIEwwLjAwMTAwMDAwMDgzLDMzLjA1MiBaIiBpZD0iU2hhcGUiIGZpbGw9IiMyNjQ5ODEiPjwvcGF0aD4gICAgICAgICAgICA8cGF0aCBkPSJNNi41LDM5IEMzLjE1NiwzOSAtMS4xOTIwOTE3NmUtMDksMzYuOTgzIC0xLjE5MjA5MTc2ZS0wOSwzMy41IEwtMS4xOTIwOTE3NmUtMDksMzEgTDE1LDMxIEw3LDM5IEw2LjUsMzkgWiIgaWQ9IlNoYXBlIiBmaWxsPSIjNDM1QjhFIj48L3BhdGg+ICAgICAgICAgICAgPHBhdGggZD0iTTguMzQ0NjQ5NDJlLTEwLDE4Ljk5OTk5OTggTDguMzQ0NjQ5NDJlLTEwLDEwLjk5MSBMMzQuODE0LDEwLjk5MSBMMjcuMDAwMDAwNywxOC45OTk5OTk4IEw4LjM0NDY0OTQyZS0xMCwxOC45OTk5OTk4IFoiIGlkPSJTaGFwZSIgZmlsbD0iIzY3QTNDQyI+PC9wYXRoPiAgICAgICAgICAgIDxwYXRoIGQ9Ik0tMS4xOTIwOTUzMWUtMDksMjkgTC0xLjE5MjA5NTMxZS0wOSwyMSBMMjQuOTk5OTk5MywyMSBMMTYuOTk5OTk5MywyOSBMLTEuMTkyMDk1MzFlLTA5LDI5IFoiIGlkPSJTaGFwZSIgZmlsbD0iIzUzNzJBQSI+PC9wYXRoPiAgICAgICAgPC9nPiAgICA8L2c+PC9zdmc+');
+     position:relative;
+     transition:background-position .1s ease-in-out;
+     margin-right:5px 
+}
+ .topbar .icon-site-switcher-bubble .icon-hamburger,.topbar .icon-site-switcher-bubble .icon-hamburger:before,.topbar .icon-site-switcher-bubble .icon-hamburger:after{
+     position:absolute;
+     left:0;
+     top:50%;
+     margin-top:-1px;
+     display:inline-block;
+     width:8px;
+     height:2px;
+     background:#6a737c;
+     border-radius:0 2px 2px 0;
+     transition:width .1s ease-in-out 
+}
+ .topbar .icon-site-switcher-bubble .icon-hamburger:before,.topbar .icon-site-switcher-bubble .icon-hamburger:after{
+     content:'';
+     margin-top:-6px 
+}
+ .topbar .icon-site-switcher-bubble .icon-hamburger:after{
+     margin-top:4px 
+}
+ .topbar .icon-site-switcher-bubble.topbar-icon-on{
+     background-position:13px 11px 
+}
+ .topbar .icon-site-switcher-bubble.topbar-icon-on .icon-hamburger,.topbar .icon-site-switcher-bubble.topbar-icon-on .icon-hamburger:before,.topbar .icon-site-switcher-bubble.topbar-icon-on .icon-hamburger:after{
+     width:0 
+}
+ .topbar .siteSwitcher-dialog,.topbar .inbox-dialog,.topbar .achievements-dialog,.topbar .modInbox-dialog{
+     min-width:300px;
+     width:100% 
+}
+ .topbar .login-links-container{
+     display:-webkit-flex;
+     display:flex;
+     -webkit-align-items:center;
+     align-items:center 
+}
+ .topbar .login-links-container a{
+     display:inline-block;
+     padding:0 10px;
+     font-size:13px;
+     color:#fff 
+}
+ .topbar .unread-count{
+     display:inline-block;
+     color:#fff;
+     text-align:center;
+     text-indent:0;
+     border-radius:2px;
+     padding:4px 6px 3px;
+     font-size:11px;
+     line-height:1;
+     position:absolute;
+     min-width:22px 
+}
+ .nav{
+     background-color:#242729;
+     box-shadow:inset 0 -1px 0 rgba(0,0,0,0.1);
+     width:100%;
+     text-align:center;
+     height:44px;
+     font-size:0 
+}
+ .nav ul{
+     margin:0 
+}
+ .nav li{
+     display:inline-block;
+     list-style:none;
+     padding:8px 0 
+}
+ .nav a,.nav a:visited{
+     font-size:11px;
+     color:rgba(255,255,255,0.7);
+     line-height:20px;
+     display:inline-block;
+     padding:4px 5px;
+     border-radius:1px 
+}
+ .nav li.current{
+     margin:0 3px 
+}
+ .nav li.current a{
+     background:#fff;
+     color:#242729;
+     padding-right:7px;
+     padding-left:7px;
+     font-weight:500 
+}
+ 

--- a/src/sotoki/renderer.py
+++ b/src/sotoki/renderer.py
@@ -157,7 +157,7 @@ class Renderer(GlobalMixin):
                 self.database.tags_key(), num=10, scored=False
             ),
             questions=extend_questions(page),
-            to_root="",
+            to_root="./",
             page_obj=page,
             **self.global_context,
         )

--- a/src/sotoki/scraper.py
+++ b/src/sotoki/scraper.py
@@ -130,7 +130,7 @@ class StackExchangeToZim:
 
         # download primary|secondary.css from target
         assets_base = Global.site["IconUrl"].rsplit("/", 2)[0]
-        for css_fname in ("primary.css", "secondary.css", "mobile.css"):
+        for css_fname in ("primary.css", "secondary.css"):
             logger.debug(f"adding {css_fname}")
             Global.creator.add_item(
                 URLItem(

--- a/src/sotoki/templates/base.html
+++ b/src/sotoki/templates/base.html
@@ -10,28 +10,12 @@
         <link rel="stylesheet" type="text/css" href="{{ to_root }}static/css/stacks.css" />
         <link id="primary_css" rel="stylesheet" type="text/css" href="{{ to_root }}static/css/primary.css" />
         <link id="secondary_css" rel="stylesheet" type="text/css" href="{{ to_root }}static/css/secondary.css" />
+        <link rel="stylesheet" type="text/css" href="{{ to_root }}static/css/sotoki.css" />
         <style type="text/css">
-            {{ site_css }}
-            body { padding-top: 0; } /* we don't include SE's topbar */
-            .mobile-only { display: none; }
-            body.mobile .mobile-only { display: block; }
-            body.mobile .desktop-only { display: none; }
-            body.mobile.user-page .container { display: none; }
-            body.mobile .post-layout--left, body.mobile .post-layout--left.votecell { padding-right: 0; }
-            html.html__responsive:not(.html__unpinned-leftnav) body.mobile #content { padding-left: 8px; padding-right: 8px; }
-            /*body.mobile.tagged-questions-page #questions.pl24 { padding-left:0 !important; }*/
-            body.mobile.tagged-questions-page #questions.pl24 .mln24 { margin-left: 0 !important; }
-            .about-text { padding-bottom: 16px; padding-top: 16px; }
-            a.external-link {
-                background-image: url({{ to_root }}static/img/external-link-ltr-icon.svg);
-                background-position: center right;
-                background-repeat: no-repeat;
-                padding-right: 13px;
-            }
-            .kiwix_searchform input.ui-autocomplete-input { margin-top: 0; margin-bottom: 0; }
-            .kiwix_searchform { font-size: 14px; }
+            a.external-link { background-image: url('{{ to_root }}static/img/external-link-ltr-icon.svg'); }{% if site_css %}
+            {{ site_css }}{% endif %}
         </style>
-        <script type="text/javascript" src="{{ to_root }}static/js/jdenticon.min.js" async></script>
+        <script type="text/javascript" src="{{ to_root }}static/js/jdenticon.min.js"></script>
         <script type="text/javascript" src="{{ to_root }}static/js/webp-hero.polyfill.js"></script>
         <script type="text/javascript" src="{{ to_root }}static/js/webp-hero.bundle.js"></script>
         <script type="text/javascript" src="{{ to_root }}static/js/webp-handler.js"></script>
@@ -51,7 +35,7 @@
             }
             var webp_handler = new WebPHandler({
                 on_error: replaceWithJdenticon,
-                scripts_urls: ["static/js/webp-hero.polyfill.js", "static/js/webp-hero.bundle.js"],
+                scripts_urls: ["{{ to_root }}static/js/webp-hero.polyfill.js", "{{ to_root }}static/js/webp-hero.bundle.js"],
             });
 
             /*
@@ -83,8 +67,8 @@
                     tex2jax: { inlineMath: [ ["$", "$"], ["\\\\(","\\\\)"] ], displayMath: [ ["$$","$$"], ["\\[", "\\]"] ], processEscapes: true, ignoreClass: "tex2jax_ignore|dno" },
                     TeX: {
                         extensions: ["begingroup.js"],
-                        noUndefined: { attributes: { mathcolor: "red", mathbackground: "#FFEEEE", mathsize: "90%" } }, 
-                        Macros: { href: "{}" } 
+                        noUndefined: { attributes: { mathcolor: "red", mathbackground: "#FFEEEE", mathsize: "90%" } },
+                        Macros: { href: "{}" }
                     },
                     messageStyle: "none",
                     styles: { ".MathJax_Display, .MathJax_Preview, .MathJax_Preview > *": { "background": "inherit" } },
@@ -174,15 +158,6 @@
             StackExchange.ready(function () {
                 // syntax highlighting
                 styleCode();
-                // enable mobile CSS if browser is detected as mobile
-                if (MathJax.Hub.Browser.isMobile) {
-                    $('head').append('<link rel="stylesheet" href="{{ to_root }}static/css/mobile.css" type="text/css" />');
-                    $('body').addClass('mobile');
-                    // user profile requires removing primary css
-                    {% if body_class == "user-page" %}
-                    $('#primary_css').remove();
-                    {% endif %}
-                }
             });
         </script>
         <script>

--- a/src/sotoki/templates/questions.html
+++ b/src/sotoki/templates/questions.html
@@ -17,7 +17,7 @@
                     <div class="fs-body3 grid--cell fl1 mr12 sm:mr0 sm:mb12">{{ page_obj.paginator.count }} questions</div>
                 </div>
             </div>
-            <div id="questions" class="flush-left">
+            <div id="questions">
                 {% for question in questions %}
                     {% include "question_list_item.html" %}
                 {% endfor %}

--- a/src/sotoki/templates/user.html
+++ b/src/sotoki/templates/user.html
@@ -1,137 +1,102 @@
 {% extends "base.html" %}
-{% block fullwidth %}
-<main class="mobile-only">
-    <div class="subheader _profile">
-        <div class="-top">
-            <a href="{{ to_root }}users/{{ Id }}/{{ slug }}" class="-avatar">
-                <div class="gravatar-wrapper-48">
-                    <img class="bar-sm" src="{{ to_root }}users/profiles/{{ Id }}.webp" width="48" height="48" data-jdenticon-value="{{ DisplayName }}" onerror="javascript:onImageLoadingError.call(this);" />
-                </div>
-            </a>
-            <div class="-details">
-                <h1 class="grid ai-center gs4 fw-wrap">{{ DisplayName }}</h1>
-                <div class="-stats">
-                    <strong class="reputation-score">{{ Reputation|number }}</strong>
-                    <span class="badge-wrapper _badge2"><span class="badge2">●</span><span class="badgecount">5</span></span>
-                    <span class="badge-wrapper _badge3"><span class="badge3">●</span><span class="badgecount">9</span></span>
-                </div><!-- / stats -->
-            </div><!-- / details -->
-        </div><!-- / top -->
-    </div>
-
-    {% if AboutMe %}<div class="user-panel wrapper _inner s-prose js-post-body _card">{{ AboutMe|rewrote(to_root) }}</div>{% endif %}
-    {% if Location %}
-    <div class="user-panel wrapper _inner _card">
-        <ul><li><span class="icon-location"></span>
-        {{ Location }}</li></ul>
-    </div>
-    {% endif %}
-</main>
-{% endblock %}
 {% block content %}
-    <div id="mainbar-full desktop-only">
+    <div id="mainbar-full">
             <div id="user-card" class="user-card">
-            <div class="grid gs24">
-                <div class="grid--cell fl-shrink0 ws2 overflow-hidden">
-                    <div id="avatar-card" class="profile-avatar s-card mb16 p12 bc-black-100 ta-center">
-                        <div class="avatar mt16 mx-auto overflow-hidden">
-                            <a class="d-block" href="{{ to_root }}users/{{ Id }}/{{ slug }}">
-                                <div class="gravatar-wrapper-164">
-                                    <img class="bar-sm" src="{{ to_root }}users/profiles/{{ Id }}.webp" width="164" height="164" data-jdenticon-value="{{ DisplayName }}" onerror="javascript:onImageLoadingError(this);" />
-                                </div>
-                            </a>
-                        </div>
-                    <div class="my12 fw-normal lh-sm" title="reputation">
-                        <div class="grid gs8 grid__center">
-                            <div class="grid--cell fs-title fc-dark">{{ Reputation|number }}</div>
-                            <div class="grid--cell fs-fine fc-light tt-uppercase">reputation</div>
-                        </div>
-                    </div>
-                    {% if nb_gold or nb_silver or nb_bronze %}
-                    <div class="m4">
-                        <div class="grid gs4 grid__fl1">
-                            {% if nb_gold %}
-                            <div class="grid--cell">
-                                <div class="grid ai-center s-badge s-badge__gold" title="{{ nb_gold }} gold badges">
-                                    <span class="grid--cell badge1"></span>
-                                    <span class="grid grid__center fl1">{{ nb_gold }}</span>
-                                </div>
+                <h2 class="fw-wrap ai-center fs-headline1 lh-xs fc-dark wb-break-all profile-user--name"><div class="grid--cell fw-bold">{{ DisplayName }}</div></h2>
+
+                <div class="profile-box d-flex">
+                    <div class="reputation-box flex--item fl-shrink0 ws2 overflow-hidden">
+                        <div id="avatar-card" class="profile-avatar s-card mb16 p12 bc-black-100 ta-center">
+                            <div class="avatar mt16 mx-auto overflow-hidden">
+                                <a class="d-block" href="{{ to_root }}users/{{ Id }}/{{ slug }}">
+                                    <div class="gravatar-wrapper-164">
+                                        <img class="bar-sm" src="{{ to_root }}users/profiles/{{ Id }}.webp" width="164" height="164" data-jdenticon-value="{{ DisplayName }}" onerror="javascript:onImageLoadingError(this);" />
+                                    </div>
+                                </a>
                             </div>
-                            {% endif %}
-                            {% if nb_silver %}
-                            <div class="grid--cell">
-                                <div class="grid ai-center s-badge s-badge__silver" title="{{ nb_silver }} silver badges">
-                                    <span class="grid--cell badge2"></span>
-                                    <span class="grid grid__center fl1">{{ nb_silver }}</span>
-                                </div>
+                        <div class="my12 fw-normal lh-sm" title="reputation">
+                            <div class="grid gs8 grid__center">
+                                <div class="grid--cell fs-title fc-dark">{{ Reputation|number }}</div>
+                                <div class="grid--cell fs-fine fc-light tt-uppercase">reputation</div>
                             </div>
-                            {% endif %}
-                            {% if nb_bronze %}
-                            <div class="grid--cell">
-                                <div class="grid ai-center s-badge s-badge__bronze" title="{{ nb_bronze }} bronze badges">
-                                    <span class="grid--cell badge3"></span>
-                                    <span class="grid grid__center fl1">{{ nb_bronze }}</span>
-                                </div>
-                            </div>
-                            {% endif %}
                         </div>
-                    </div>
-                    {% endif %}
-                    </div>
-                </div>
-                <div class="grid--cell fl1 wmn0">
-                    <div class="grid gs16">
-                        <div class="grid--cell fl1 w0 pr16 profile-user--about about">
-                            <div class="grid fd-column gs8 gsy">
+                        {% if nb_gold or nb_silver or nb_bronze %}
+                        <div class="m4">
+                            <div class="grid gs4 grid__fl1">
+                                {% if nb_gold %}
                                 <div class="grid--cell">
-                                    <h2 class="grid gs4 fw-wrap ai-center fs-headline1 lh-xs fc-dark wb-break-all profile-user--name">
-                                        <div class="grid--cell fw-bold">{{ DisplayName }}</div>
-                                    </h2>
+                                    <div class="grid ai-center s-badge s-badge__gold" title="{{ nb_gold }} gold badges">
+                                        <span class="grid--cell badge1"></span>
+                                        <span class="grid grid__center fl1">{{ nb_gold }}</span>
+                                    </div>
                                 </div>
-                                {% if AboutMe %}<div class="grid--cell mt16 s-prose profile-user--bio ">
-                                {{ AboutMe|rewrote(to_root) }}
-                                </div>{% endif %}
+                                {% endif %}
+                                {% if nb_silver %}
+                                <div class="grid--cell">
+                                    <div class="grid ai-center s-badge s-badge__silver" title="{{ nb_silver }} silver badges">
+                                        <span class="grid--cell badge2"></span>
+                                        <span class="grid grid__center fl1">{{ nb_silver }}</span>
+                                    </div>
+                                </div>
+                                {% endif %}
+                                {% if nb_bronze %}
+                                <div class="grid--cell">
+                                    <div class="grid ai-center s-badge s-badge__bronze" title="{{ nb_bronze }} bronze badges">
+                                        <span class="grid--cell badge3"></span>
+                                        <span class="grid grid__center fl1">{{ nb_bronze }}</span>
+                                    </div>
+                                </div>
+                                {% endif %}
                             </div>
                         </div>
-                        <div class="grid--cell fl-shrink0 pr24 wmx3">
-                            <div class="ps-relative s-anchors s-anchors__inherit">
-                                <ul class="list-reset grid gs8 gsy fd-column fc-medium">
-                                    {% if Location %}
-                                    <li class="grid--cell ow-break-word">
-                                            <div class="grid gs8 gsx ai-center">
-                                                <div class="grid--cell fc-black-350"><svg aria-hidden="true" class="svg-icon iconLocation" width="18" height="18" viewBox="0 0 18 18"><path d="M2 6.38C2 9.91 8.1 17.7 8.1 17.7c.22.29.58.29.8 0 0 0 6.1-7.8 6.1-11.32A6.44 6.44 0 008.5 0 6.44 6.44 0 0 0 2 6.38zm9.25.12a2.75 2.75 0 11-5.5 0 2.75 2.75 0 0 1 5.5 0z"></path></svg></div>
-                                                <div class="grid--cell fl1">{{ Location }}</div>
-                                            </div>
-                                        </li>
-                                    {% endif %}
-                                    <li class="grid--cell ow-break-word">
-                                        <div class="grid gs8 gsx ai-center">
-                                            <div class="grid--cell fc-black-350">
-                                                <svg aria-hidden="true" class="svg-icon iconHistory" width="19" height="18" viewBox="0 0 19 18">
-                                                    <path d="M3 9a8 8 0 113.73 6.77L8.2 14.3A6 6 0 105 9l3.01-.01-4 4-4-4h3L3 9zm7-4h1.01L11 9.36l3.22 2.1-.6.93L10 10V5z"></path>
-                                                </svg>
-                                            </div>
-                                            <div class="grid--cell fl1">Member for <span title="2021-03-30 19:16:33Z">{{ CreationDate }} months</span></div>
-                                        </div>
-                                    </li>
-                                    <li class="grid--cell ow-break-word">
-                                        <div class="grid gs8 gsx ai-center">
-                                            <div class="grid--cell fc-black-350"><svg aria-hidden="true" class="svg-icon iconEye" width="18" height="18" viewBox="0 0 18 18"><path d="M9.06 3C4 3 1 9 1 9s3 6 8.06 6C14 15 17 9 17 9s-3-6-7.94-6zM9 13a4 4 0 110-8 4 4 0 0 1 0 8zm0-2a2 2 0 002-2 2 2 0 0 0-2-2 2 2 0 0 0-2 2 2 2 0 0 0 2 2z"></path></svg></div>
-                                            <div class="grid--cell fl1">{{ Views }} profile views</div>
-                                        </div>
-                                    </li>
-                                    <li class="grid--cell ow-break-word">
-                                        <div class="grid gs8 gsx ai-center">
-                                            <div class="grid--cell fc-black-350"><svg aria-hidden="true" class="svg-icon iconClock" width="18" height="18" viewBox="0 0 18 18"><path d="M9 17c-4.36 0-8-3.64-8-8 0-4.36 3.64-8 8-8 4.36 0 8 3.64 8 8 0 4.36-3.64 8-8 8zm0-2c3.27 0 6-2.73 6-6s-2.73-6-6-6-6 2.73-6 6 2.73 6 6 6zM8 5h1.01L9 9.36l3.22 2.1-.6.93L8 10V5z"></path></svg></div>
-                                            <div class="grid--cell fl1">Last seen <span title="2021-04-30 06:44:24Z" class="relativetime">{{ LastAccessDate|datetime }}</span></div>
-                                        </div>
-                                    </li>
-                                </ul>
-                            </div>
+                        {% endif %}
                         </div>
                     </div>
+
+                    <div class="flex-spacer flex--item fl-grow1 ws1"></div>
+
+                    <div class="metadata-box flex--item pr24 wmx3">
+                        <div class="ps-relative s-anchors s-anchors__inherit">
+                            <ul class="list-reset grid gs8 gsy fd-column fc-medium">
+                                {% if Location %}
+                                <li class="grid--cell ow-break-word">
+                                        <div class="grid gs8 gsx ai-center">
+                                            <div class="grid--cell fc-black-350"><svg aria-hidden="true" class="svg-icon iconLocation" width="18" height="18" viewBox="0 0 18 18"><path d="M2 6.38C2 9.91 8.1 17.7 8.1 17.7c.22.29.58.29.8 0 0 0 6.1-7.8 6.1-11.32A6.44 6.44 0 008.5 0 6.44 6.44 0 0 0 2 6.38zm9.25.12a2.75 2.75 0 11-5.5 0 2.75 2.75 0 0 1 5.5 0z"></path></svg></div>
+                                            <div class="grid--cell fl1">{{ Location }}</div>
+                                        </div>
+                                    </li>
+                                {% endif %}
+                                <li class="grid--cell ow-break-word">
+                                    <div class="grid gs8 gsx ai-center">
+                                        <div class="grid--cell fc-black-350">
+                                            <svg aria-hidden="true" class="svg-icon iconHistory" width="19" height="18" viewBox="0 0 19 18">
+                                                <path d="M3 9a8 8 0 113.73 6.77L8.2 14.3A6 6 0 105 9l3.01-.01-4 4-4-4h3L3 9zm7-4h1.01L11 9.36l3.22 2.1-.6.93L10 10V5z"></path>
+                                            </svg>
+                                        </div>
+                                        <div class="grid--cell fl1">Member for <span title="2021-03-30 19:16:33Z">{{ CreationDate }} months</span></div>
+                                    </div>
+                                </li>
+                                <li class="grid--cell ow-break-word">
+                                    <div class="grid gs8 gsx ai-center">
+                                        <div class="grid--cell fc-black-350"><svg aria-hidden="true" class="svg-icon iconEye" width="18" height="18" viewBox="0 0 18 18"><path d="M9.06 3C4 3 1 9 1 9s3 6 8.06 6C14 15 17 9 17 9s-3-6-7.94-6zM9 13a4 4 0 110-8 4 4 0 0 1 0 8zm0-2a2 2 0 002-2 2 2 0 0 0-2-2 2 2 0 0 0-2 2 2 2 0 0 0 2 2z"></path></svg></div>
+                                        <div class="grid--cell fl1">{{ Views }} profile views</div>
+                                    </div>
+                                </li>
+                                <li class="grid--cell ow-break-word">
+                                    <div class="grid gs8 gsx ai-center">
+                                        <div class="grid--cell fc-black-350"><svg aria-hidden="true" class="svg-icon iconClock" width="18" height="18" viewBox="0 0 18 18"><path d="M9 17c-4.36 0-8-3.64-8-8 0-4.36 3.64-8 8-8 4.36 0 8 3.64 8 8 0 4.36-3.64 8-8 8zm0-2c3.27 0 6-2.73 6-6s-2.73-6-6-6-6 2.73-6 6 2.73 6 6 6zM8 5h1.01L9 9.36l3.22 2.1-.6.93L8 10V5z"></path></svg></div>
+                                        <div class="grid--cell fl1">Last seen <span title="2021-04-30 06:44:24Z" class="relativetime">{{ LastAccessDate|datetime }}</span></div>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+
                 </div>
+
+
             </div>
-        </div>
+
+            {% if AboutMe %}<div class="grid--cell mt16 s-prose profile-user--bio ">{{ AboutMe|rewrote(to_root) }}</div>{% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Following SE, we previously had two versions of the user profile, triggered by
some _mobile_ device detection in JS.

This was bad for several reasons:
- No JS had broken User profiles
- dependency on MathJax JS for that detection
- User profile content inserted twice (storage, DB queries)
- Complexity of templates and code (mobile.css conflicts with primary.css)

We now have a custom, SE inspired User profile that is responsive down to mobile as well

Additionaly:
- we don't download mobile.css from source
- we moved our growing css to a dedicated file (sotoki.css)
- topbar and rest of mobile-specific is now triggered solely by media queries
- part of sotoki.css is copied from mobile.css
- fixed link to home on questions list
- fixed links to webppolyfill on non-root paths
- fixed jdenticon loading (was async but relied upon immediately)
- various fixes to mobile-specific UI