### PR TITLE
Use MD5 when naming image files

### DIFF
--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -4,7 +4,7 @@
 
 import io
 import re
-import zlib
+import hashlib
 import urllib.parse
 from typing import Optional
 
@@ -153,7 +153,8 @@ class Imager:
 
     def get_digest_for(self, url: str) -> str:
         """Unique identifier of that url"""
-        return zlib.adler32(url.encode("UTF-8"))
+        return hashlib.md5(url.encode("UTF-8"), usedforsecurity=False).hexdigest()
+
 
     def get_version_ident_for(self, url: str) -> str:
         """~version~ of the URL data to use for comparisons. Built from headers"""

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -153,7 +153,7 @@ class Imager:
 
     def get_digest_for(self, url: str) -> str:
         """Unique identifier of that url"""
-        return hashlib.md5(url.encode("UTF-8")).hexdigest()  #nosec
+        return hashlib.md5(url.encode("UTF-8")).hexdigest()  # nosec
 
 
     def get_version_ident_for(self, url: str) -> str:

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -153,7 +153,7 @@ class Imager:
 
     def get_digest_for(self, url: str) -> str:
         """Unique identifier of that url"""
-        return hashlib.md5(url.encode("UTF-8")).hexdigest()
+        return hashlib.md5(url.encode("UTF-8")).hexdigest()  #nosec
 
 
     def get_version_ident_for(self, url: str) -> str:

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -153,7 +153,7 @@ class Imager:
 
     def get_digest_for(self, url: str) -> str:
         """Unique identifier of that url"""
-        return hashlib.md5(url.encode("UTF-8"), usedforsecurity=False).hexdigest()
+        return hashlib.md5(url.encode("UTF-8")).hexdigest()
 
 
     def get_version_ident_for(self, url: str) -> str:


### PR DESCRIPTION
This changes the way image files are named from the more collision-prone Adler32 checksums to MD5 hashes

Fixes #284 