### PR TITLE
Upgrade python-scraperlib to 3.X (implement #290)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 kiwixstorage>=0.8.1,<1.0
 pif>=0.8.2,<0.9
-zimscraperlib>=3.2.0,<4.0
+zimscraperlib>=3.3.0,<4.0
 xml_to_dict>=0.1.6,<0.2
 cli-formatter>=1.2.0,<1.3
 py7zr>=0.20.4,<0.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 kiwixstorage>=0.8.1,<1.0
 pif>=0.8.2,<0.9
-zimscraperlib>=2.1,<3.0
+zimscraperlib>=3.2.0,<4.0
 xml_to_dict>=0.1.6,<0.2
 cli-formatter>=1.2.0,<1.3
 py7zr>=0.20.4,<0.21

--- a/src/sotoki/constants.py
+++ b/src/sotoki/constants.py
@@ -96,10 +96,12 @@ class Sotoconf:
     name: str
     title: Optional[str] = ""
     description: Optional[str] = ""
+    long_description: Optional[str] = ""
     author: Optional[str] = ""
     publisher: Optional[str] = ""
     fname: Optional[str] = ""
     tag: List[str] = field(default_factory=list)
+    flavour: Optional[str] = ""
     iso_langs_1: List[str] = field(default_factory=list)  # ISO-639-1
     iso_langs_3: List[str] = field(default_factory=list)  # ISO-639-3
 
@@ -193,9 +195,9 @@ class Sotoconf:
         self.dump_domain = self.domain  # dumps are named after unfixed domains
         self.domain = FIXED_DOMAINS.get(self.domain, self.domain)
         self.iso_langs_1, self.iso_langs_3 = langs_for_domain(self.domain)
-        variant = "nopic" if self.without_images else "all"
+        self.flavour = "nopic" if self.without_images else "all"
         lang_in_name = self.iso_langs_1[0] if len(self.iso_langs_1) == 1 else "mul"
-        self.name = self.name or f"{self.domain}_{lang_in_name}_{variant}"
+        self.name = self.name or f"{self.domain}_{lang_in_name}_{self.flavour}"
         self.output_dir = pathlib.Path(self._output_dir).expanduser().resolve()
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.tmp_dir = pathlib.Path(self._tmp_dir).expanduser().resolve()

--- a/src/sotoki/entrypoint.py
+++ b/src/sotoki/entrypoint.py
@@ -97,6 +97,10 @@ def main():
         "--description",
         help="Custom description for your ZIM. Site tagline otherwise",
     )
+    metadata.add_argument(
+        "--long-description",
+        help="Custom long description for your ZIM, defaults to description",
+    )
 
     metadata.add_argument(
         "--favicon",

--- a/src/sotoki/entrypoint.py
+++ b/src/sotoki/entrypoint.py
@@ -99,7 +99,8 @@ def main():
     )
     metadata.add_argument(
         "--long-description",
-        help="Custom long description for your ZIM, defaults to description",
+        help="Custom long description for your ZIM, defaults to description if description is too long",
+        required=False,
     )
 
     metadata.add_argument(

--- a/src/sotoki/scraper.py
+++ b/src/sotoki/scraper.py
@@ -96,23 +96,6 @@ class StackExchangeToZim:
         self.conf.publisher = self.conf.publisher.strip()
 
     def add_illustrations(self):
-        src_illus_fpath = self.build_dir / "illustration"
-
-        # if user provided a custom favicon, retrieve that
-        if not self.conf.favicon:
-            self.conf.favicon = Global.site["BadgeIconUrl"]
-        handle_user_provided_file(source=self.conf.favicon, dest=src_illus_fpath)
-
-        # convert to PNG (might already be PNG but it's OK)
-        illus_fpath = src_illus_fpath.with_suffix(".png")
-        convert_image(src_illus_fpath, illus_fpath)
-
-        # resize to appropriate size (ZIM uses 48x48 so we double for retina)
-        for size in (96, ):  # 48x48 illustration is added during metadata configuration
-            resize_image(illus_fpath, width=size, height=size, method="thumbnail")
-            with open(illus_fpath, "rb") as fh:
-                Global.creator.add_illustration(size, fh.read())
-
         # download and add actual favicon (ICO file)
         favicon_fpath = self.build_dir / "favicon.ico"
         handle_user_provided_file(source=Global.site["IconUrl"], dest=favicon_fpath)

--- a/src/sotoki/scraper.py
+++ b/src/sotoki/scraper.py
@@ -78,14 +78,11 @@ class StackExchangeToZim:
         self.conf.title = self.conf.title.strip()
 
         default_description = Global.site["Tagline"].strip()
-        if self.conf.description is not None:
+        if self.conf.description:
             user_description = self.conf.description.strip()
         else:
             user_description = None
-        user_long_description = self.conf.long_description
-        description, long_description = compute_descriptions(default_description, user_description, user_long_description)
-        self.conf.description = description
-        self.conf.long_description = long_description
+        self.conf.description, self.conf.long_description = compute_descriptions(default_description, user_description, self.conf.long_description)
 
         if not self.conf.author:
             self.conf.author = "Stack Exchange"


### PR DESCRIPTION
(PR depends on https://github.com/openzim/python-scraperlib/pull/126 and will likely need at least one revision due to some feedback being needed)

This PR upgrades `python-scraperlib` to 3.x while also adding a `--long-description argument`. This implements #290.

**Changes:**

- upgrade python-scraperlib
- add `--long-description` argument (`--description` already exists and was not needed to be added). It defaults to the tagline.
- The `Description` metadata is now limited in length to conform with python-scraberlibs metadata validation, which enforces a maximum length
- `Flavour` and `Scraper` metadata will now be set

**Test status:**

- tested manual build with `sotoki --debug --domain="boardgames.stackexchange.com" --mirror="https://org-kiwix-stackexchange.s3.us-west-1.wasabisys.com" --output="./output" --threads="28" --stats-filename="./task_progress.json" --publisher="openZIM"` as well as `--description="test description" --long-description="test long description"`.
- `zimcheck` complains about article contents, redundancy and missing links, but I don't think the missing profile pictures are related to the changes.

**Comments:**

-  python-scraperlib now enforces a maximum length for description. Previously, the description defaulted to the site tagline, but these can exceed the maximum length. I've changed the behavior to only use at most as many characters as are allowed, but this can split the tagline suddenly and I think the results can be quite ugly. Any ideas for a better implementation? Just raising an exception would likely break some zimfarm recipes that do no excplicitly set a description.
- the long description now defaults to the  unshortened/less shortened version of the description. Not sure if perhaps another value or omitting it by default would be preferable.
- The favicon/`Illustration_48x48@1` needed a rework, as it now needs to be specified when calling `.config_metadata()`. I had to move the conversion for the 48x48 image to the creator setup, but this led to some duplicate code and is a IMO rather ugly solution. Some feedback on how to refactor the code to avoid this would be appreciated.

**Edit:**

This PR fixes #290