### PR TITLE
Update publisher metadata from 'Kiwix' to 'openZIM'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Name` metadata to be like "{domain}_mul_{variant}"
   - Filename metadata to match `Name`
 - Using zimscraperlib 2.1
+- Changed default publisher metadata from 'Kiwix' to 'openZIM'
 
 ## [2.0.2] - 2022-10-31
 

--- a/src/sotoki/entrypoint.py
+++ b/src/sotoki/entrypoint.py
@@ -113,7 +113,7 @@ def main():
         "-p",
         "--publisher",
         help="Custom publisher name (ZIM metadata). “OpenZIM” otherwise",
-        default="Kiwix",
+        default="openZIM",
     )
     metadata.add_argument(
         "--tag",

--- a/src/sotoki/entrypoint.py
+++ b/src/sotoki/entrypoint.py
@@ -112,8 +112,7 @@ def main():
     metadata.add_argument(
         "-p",
         "--publisher",
-        help="Custom publisher name (ZIM metadata). “OpenZIM” otherwise",
-        default="openZIM",
+        help="Custom publisher name (ZIM metadata). “openZIM” otherwise"
     )
     metadata.add_argument(
         "--tag",

--- a/src/sotoki/scraper.py
+++ b/src/sotoki/scraper.py
@@ -86,7 +86,7 @@ class StackExchangeToZim:
         self.conf.author = self.conf.author.strip()
 
         if not self.conf.publisher:
-            self.conf.publisher = "Openzim"
+            self.conf.publisher = "openZIM"
         self.conf.publisher = self.conf.publisher.strip()
 
     def add_illustrations(self):


### PR DESCRIPTION
Resolves #291
Updated publisher metadata to 'openZIM' in `entrypoint.py` and `scraper.py`.