### PR TITLE
Use same Debian release for redis and final container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM redis:6.2.4-buster AS redis
 
-FROM python:3.8-slim
+FROM python:3.8-slim-buster
 
 RUN groupadd -r -g 999 redis && useradd -r -g redis -u 999 redis
 COPY --from=redis /usr/local/bin/redis-server /usr/local/bin/redis-server


### PR DESCRIPTION
Fix #294 

## Changes

Align Debian release (`buster` for now) between the Redis image and the final container image

Nota: we will obviously have to upgrade to bookworm and Python 3.12 at some point, but let's live with it for the coming weeks