### PR TITLE
Automatically publish to Pypi

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -1,0 +1,43 @@
+name: Build and upload to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write  # mandatory for PyPI trusted publishing
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8' # manual configuration until Python bootstrap is implemented
+          # python-version-file: pyproject.toml
+          architecture: x64
+
+      - name: Build packages
+        run: |
+          pip install -U pip build
+          python -m build --sdist --wheel
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.8
+
+      - name: Build and push Docker image
+        uses: openzim/docker-publish-action@v10
+        with:
+          image-name: openzim/sotoki
+          tag-pattern: /^v([0-9.]+)$/
+          latest-on-tag: true
+          restrict-to: openzim/sotoki
+          registries: ghcr.io
+          credentials:
+            GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
+            GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
+          repo_description: auto
+          repo_overview: auto

--- a/.github/workflows/PublishDockerDevImage.yml
+++ b/.github/workflows/PublishDockerDevImage.yml
@@ -1,29 +1,27 @@
-name: Docker
+name: Publish Docker dev image
 
 on:
   push:
     branches:
       - main
-    tags:
-      - v*
 
 jobs:
-  build-and-push:
-    name: Deploy Docker Image
+  publish:
     runs-on: ubuntu-22.04
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Build and push
+      - uses: actions/checkout@v3
+
+      - name: Build and push Docker image
         uses: openzim/docker-publish-action@v10
         with:
           image-name: openzim/sotoki
-          on-master: dev
-          tag-pattern: /^v([0-9.]+)$/
-          latest-on-tag: true
+          manual-tag: dev
+          latest-on-tag: false
           restrict-to: openzim/sotoki
-          repo_description: auto
-          repo_overview: auto
           registries: ghcr.io
           credentials:
             GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
             GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
+          repo_description: auto
+          repo_overview: auto


### PR DESCRIPTION
Fix #303

Uses conventional jobs from Python bootstrap except that Python version is hardcoded for now, until we've moved to pyproject.toml