### PR TITLE
Fix #333: Update --redis-url to use REDIS_URL env var by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed default `--redis-url` behavior (#333)
+  - It now uses the `REDIS_URL` environment variable if set, falling back to `redis://localhost:6379`.
+  - Docker image sets `REDIS_URL` to `unix:///var/run/redis.sock` by default.
 
 ## [2.2.0] - 2025-06-10
 
@@ -65,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Multilanguage ZIM are not perfectly handled (#259)
-- Incorrect image displayed (#284) 
+- Incorrect image displayed (#284)
 - Markdown text formatting is not rendered (#286)
 - Harmonize default publisher to openZIM (#291)
 - Docker image: align redis binaries with Python distribution (#294)

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ chmod +x /usr/local/bin/start-redis-daemon
 
 RUN mkdir -p /output
 
+ENV REDIS_URL=unix:///var/run/redis.sock
 EXPOSE 6379
 ENTRYPOINT ["start-redis-daemon"]
 

--- a/src/sotoki/entrypoint.py
+++ b/src/sotoki/entrypoint.py
@@ -184,9 +184,10 @@ def main():
     advanced.add_argument(
         "--redis-url",
         help="Redis URL to use as database. "
-        "Must be redis://user?:pass?@host:port/dbnum. "
-        "Use unix:///path/to/redis.sock?db=dbnum for sockets",
-        default="redis://localhost:6379",
+        "Defaults to the REDIS_URL environment variable if set, otherwise to redis://localhost:6379. "
+        "Use redis://user:pass@host:port/db for TCP connections, or "
+        "unix:///path/to/redis.sock?db=dbnum for Unix socket connections.",
+        default=os.getenv("REDIS_URL","redis://localhost:6379"),
         dest="redis_url",
     )
 


### PR DESCRIPTION
This PR updates the default behavior of the --redis-url argument to read from the REDIS_URL environment variable, falling back to redis://localhost:6379 when not set.
Inside Docker, this allows the scraper to use the Unix socket without passing the argument explicitly.
Closes: #333 