### PR TITLE
Reduce number of workers and add backoff on 429 and non-HTTP (network, ...) errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduce number of workers and add backoff on 429 and non-HTTP (network, ...) errors
+
 ### Changed
 
 - Changed default `--redis-url` behavior (#333)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ psutil>=5.9.4,<6.0
 python-snappy>=0.6.0,<1.0
 bidict>=0.22.1,<0.23
 cchardet>=2.1.7,<2.2
+backoff==2.2.1

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib.parse
 from typing import Optional
 
+import backoff
 import requests
 from PIL import Image
 from resizeimage.imageexceptions import ImageSizeError
@@ -22,7 +23,7 @@ from ..constants import (
     IMAGES_ENCODER_VERSION,
     USER_AGENT,
 )
-from .misc import rebuild_uri
+from .misc import rebuild_uri, web_backoff
 from .shared import Global
 
 logger = Global.logger
@@ -124,6 +125,7 @@ class Imager:
         # no provider
         return url
 
+    @web_backoff
     def get_image_data(self, url: str, **resize_args: dict) -> io.BytesIO:
         """Bytes stream of an optimized, resized WebP of the source image"""
         src, webp = io.BytesIO(), io.BytesIO()
@@ -160,6 +162,7 @@ class Imager:
         return hashlib.md5(url.encode("UTF-8")).hexdigest()  # nosec
 
 
+    @web_backoff
     def get_version_ident_for(self, url: str) -> str:
         """~version~ of the URL data to use for comparisons. Built from headers"""
         try:

--- a/src/sotoki/utils/shared.py
+++ b/src/sotoki/utils/shared.py
@@ -89,7 +89,7 @@ class Global:
         # we should consider using coroutines instead of threads
         Global.img_executor = SotokiExecutor(
             queue_size=200,
-            nb_workers=100,
+            nb_workers=10,
             prefix="IMG-T-",
         )
 


### PR DESCRIPTION
This is an interim solution for #326

It is only interim because it does not really take into account 429 errors, since it only randomly retries a bit later. And since we have multiple calls in parallel, it could be that we still make too many request, or that the retry arrives at a moment where we are already making too many requests. The probability is reduced by the fact that we use only 10 threads instead of 100 (looks like it is an acceptable compromise, we will see if it causes scrape to take too long)

It is not the proper solution on the long term where we should automatically reduce the number of requests in parallel, and add a pause if needed, but only for requests of a given domain. This was deemed way too difficult to implement given current code structure: we do not expect to have a global oversight of illustrations retrieved where we could say something like "pause requests to this domain for xxx seconds".

On my tests, results are very satisfying, I do not see continuous 429 errors anymore.