### PR TITLE
Finish cleanup of users profile images

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -69,12 +69,6 @@
       "title": "Without User Profiles",
       "description": "Don't include user profile pages. Faster"
     },
-    "without_user_identicons": {
-      "type": "boolean",
-      "required": false,
-      "title": "Without Identicons",
-      "description": "Don't include user's profile pictures. Replaced by generated ones. Faster"
-    },
     "without_external_links": {
       "type": "boolean",
       "required": false,

--- a/src/sotoki/assets/static/js/identicons.js
+++ b/src/sotoki/assets/static/js/identicons.js
@@ -7,8 +7,8 @@ function replaceWithJdenticon(img) {
     if (!(img instanceof HTMLImageElement)) {
         img = img.srcElement;
     }
-    if (img.getAttribute('data-jdenticon-value') || img.getAttribute('data-jdenticon-hash')) {
-        img.parentNode.innerHTML = jdenticon.toSvg(img.getAttribute('data-jdenticon-value') || img.getAttribute('data-jdenticon-hash'), img.width || img.getAttribute("data-jdenticon-width"));
+    if (img.getAttribute('data-jdenticon-value')) {
+        img.parentNode.innerHTML = jdenticon.toSvg(img.getAttribute('data-jdenticon-value'), img.width || img.getAttribute("data-jdenticon-width"));
     }
 }
 var to_root = document.querySelector("meta[name=to_root]").getAttribute("content");
@@ -17,30 +17,9 @@ var webp_handler = new WebPHandler({
     scripts_urls: [to_root + "static/js/webp-hero.polyfill.js", to_root + "static/js/webp-hero.bundle.js"],
 });
 
-/*
- * manually set (in-templates) on all <img /> nodes so that any error loading
- * it by the browser calls it. Used to trigger polyfill and jdenticon fallback
- * /!\ requires WebPHandler to be ready _before_ the browser attempts to 
- * load any image in the page. WebP Hero scripts should thus be included
- * syncrhonously before this */
-function onImageLoadingError(img) {
-    if (img === undefined)
-        return;
-
-    // only use polyfill if browser lacks Webp supports and wasn't already polyfied
-    // polyfill replaces url with data URI
-    if (!webp_handler.supports_webp && img.src.length > 0 && img.src.substr(0, 5) != "data:") {
-        webp_handler.polyfillImage(img);
-        return;
-    }
-
-    // defaults to rendering as Jdenticon
-    replaceWithJdenticon(img);
-}
-
 document.addEventListener('DOMContentLoaded', function(){
     var img_elements = document.querySelectorAll('img');
     for (var i=0; i<img_elements.length; i++) {
-        img_elements[i].addEventListener('error', onImageLoadingError);
+        replaceWithJdenticon(img_elements[i])
     }
 });

--- a/src/sotoki/constants.py
+++ b/src/sotoki/constants.py
@@ -18,7 +18,6 @@ USER_AGENT = (
     f"{NAME}/{VERSION} (https://github.com/openzim/sotoki; "
     f"contact+crawl@kiwix.org) requests/{requests.__version__}"
 )
-PROFILE_IMAGE_SIZE = 128
 POSTS_IMAGE_SIZE = 540
 IMAGES_ENCODER_VERSION = 1
 NB_QUESTIONS_PER_TAG_PAGE = 15

--- a/src/sotoki/context.py
+++ b/src/sotoki/context.py
@@ -55,7 +55,6 @@ class Context:
     censor_words_list: str = ""
     without_images: bool = False
     without_user_profiles: bool = False
-    without_user_identicons: bool = False
     without_external_links: bool = False
     without_unanswered: bool = False
     without_users_links: bool = False
@@ -119,7 +118,3 @@ class Context:
                 except Exception:
                     return None
         return None
-
-    @property
-    def with_user_identicons(self):
-        return not self.without_images and not self.without_user_identicons

--- a/src/sotoki/templates/user.html
+++ b/src/sotoki/templates/user.html
@@ -10,7 +10,7 @@
                             <div class="avatar mt16 mx-auto overflow-hidden">
                                 <a class="d-block" href="{{ to_root }}users/{{ Id }}/{{ slug }}">
                                     <div class="gravatar-wrapper-164">
-                                        <img class="bar-sm" src="{{ to_root }}users/profiles/{{ Id }}.webp" width="164" height="164" data-jdenticon-value="{{ DisplayName }}" />
+                                        <img class="bar-sm" width="164" height="164" data-jdenticon-value="{{ DisplayName }}" />
                                     </div>
                                 </a>
                             </div>

--- a/src/sotoki/templates/user_card.html
+++ b/src/sotoki/templates/user_card.html
@@ -9,7 +9,7 @@
 <div class="s-user-card s-user-card{% if highlighted %}__highlighted{% endif %}">
     <time class="s-user-card--time{% if action_from_now %} fromnow{% endif %}" datetime="{{ action_time }}">{{ action_time|datetime }}</time>
     <a href="{{ to_root }}users/{{ user.id }}/{{ user.slug }}" class="s-avatar s-avatar__32 s-user-card--avatar">
-        <img class="s-avatar--image" src="{{ to_root }}users/profiles/{{ user.id }}.webp" data-jdenticon-width="32" data-jdenticon-height="32" data-jdenticon-value="{{ user.name }}" />
+        <img class="s-avatar--image" data-jdenticon-width="32" data-jdenticon-height="32" data-jdenticon-value="{{ user.name }}" />
     </a>
     <div class="s-user-card--info">
         <a href="{{ to_root }}users/{{ user.id }}/{{ user.slug }}" class="s-user-card--link">{{ user.name }}</a>

--- a/src/sotoki/templates/users.html
+++ b/src/sotoki/templates/users.html
@@ -12,7 +12,7 @@
                         <div class="user-gravatar48">
                             <a href="{{ to_root }}users/{{ user.id }}/{{ user.slug }}">
                                 <div class="gravatar-wrapper-48">
-                                    <img class="bar-sm" src="{{ to_root }}users/profiles/{{ user.id }}.webp" width="48" height="48" data-jdenticon-value="{{ user.name }}" />
+                                    <img class="bar-sm" width="48" height="48" data-jdenticon-value="{{ user.name }}" />
                                 </div>
                             </a>
                         </div>

--- a/src/sotoki/users.py
+++ b/src/sotoki/users.py
@@ -23,7 +23,7 @@ class UsersWalker(Walker):
         <root>
         <row Id="" Reputation="" CreationDate="" DisplayName=""
              LastAccessDate="2" WebsiteUrl="" Location="" AboutMe="" Views="" UpVotes=""
-             DownVotes="" ProfileImageUrl="" AccountId="" ><badges><badge Id=""
+             DownVotes="" AccountId="" ><badges><badge Id=""
              UserId="" Name="" Date="" Class="" TagBased="" /></badges></row>
         </root>"""
 
@@ -99,17 +99,6 @@ class UserGenerator(Generator):
                 callbacks=[Callback(func=self.release)],
             )
         del user_page
-
-        if not context.with_user_identicons:
-            return
-
-        profile_url = item.get("ProfileImageUrl")
-        if profile_url:
-            shared.imager.defer(
-                url=profile_url,
-                path=f"users/profiles/{user.id}.webp",
-                is_profile=True,
-            )
 
     def generate_users_page(self):
         paginator = ListPaginator(

--- a/src/sotoki/utils/html.py
+++ b/src/sotoki/utils/html.py
@@ -93,7 +93,6 @@ class Rewriter:
             re.compile(r"users/[0-9]+/.+"),
             re.compile(r"questions/[0-9]+/.+"),
             re.compile(r"a/[0-9]+/?$"),
-            re.compile(r"users/profiles/[0-9]+.webp$"),
             re.compile(r"questions/?$"),
             re.compile(r"questions_page=[0-9]+$"),
             re.compile(r"users/?$"),
@@ -446,7 +445,7 @@ class Rewriter:
                 if is_in_code(img):
                     continue
 
-                path = shared.imager.defer(img["src"], is_profile=False)
+                path = shared.imager.defer(img["src"])
                 if path is None:
                     del img.attrs["src"]
                 else:


### PR DESCRIPTION
Users profile images cannot be retrieved anymore because information has been classified as PII and removed from StackExchange dumps.

There is hence no need anymore to:
- keep code to retrieve the various profile images
- have fragile JS replacing profile images with generated identicons

Fix #335