### PR TITLE
Fix display of restrictions in about page

### DIFF
--- a/src/sotoki/context.py
+++ b/src/sotoki/context.py
@@ -118,3 +118,15 @@ class Context:
                 except Exception:
                     return None
         return None
+
+    @property
+    def any_restriction(self) -> bool:
+        return (
+            self.without_unanswered
+            or self.without_images
+            or self.without_user_profiles
+            or self.without_external_links
+            or self.without_users_links
+            or self.without_names
+            or bool(self.censor_words_list)
+        )

--- a/src/sotoki/templates/about.html
+++ b/src/sotoki/templates/about.html
@@ -21,6 +21,7 @@
                     <li>Content is at least few weeks old because it's a one-shot export, not being updated until you download a new ZIM, most recent question being from {{ most_recent_date }}.</li>
                     <li>Views number correspond to number of Views on the online website at the time of the Dump. Yours are not counted.</li>
                     <li>Only Users with interactions with the platform are included and thus have profile pages.</li>
+                    <li>All User's profile pictures have been removed, they are not provided in StackExchange dumps used to build this copy. You'll see generated pictures (each user has a unique one) instead.</li>
                 </ul>
 
                 {% if context.any_restriction %}
@@ -35,9 +36,6 @@
                     {% endif %}
                     {% if context.without_user_profiles %}
                         <li>All User's profile pages have been removed.</li>
-                    {% endif %}
-                    {% if context.without_user_identicons and not context.without_images %}
-                        <li>All User's profile pictures have been removed. You'll see generated ones instead.</li>
                     {% endif %}
                     {% if context.without_external_links %}
                         <li>All external links have been edited and points nowhere.</li>


### PR DESCRIPTION
Changes:
- Restrictions where not properly displayed anymore in about page
- User profile images are now always replaced by a generated image, better to mention systematically as well in about page