### PR TITLE
Enhance logic to download images to better respect upstream servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgrade to Python 3.14 + Debian bookworm (#351)
 - **BREAKING**: Replace usage of multiple `--tag` with single CSV `--tags` for Zimfarm integration (#351)
+- Enhance logic to download images to better respect upstream servers (#xxx)
 
 ### Fixed
 

--- a/src/sotoki/constants.py
+++ b/src/sotoki/constants.py
@@ -31,3 +31,10 @@ NB_USERS_PAGES = 100
 NB_PAGINATED_USERS = NB_USERS_PER_PAGE * NB_USERS_PAGES
 
 HTTP_REQUEST_TIMEOUT = 30
+MAX_FILE_DOWNLOAD_RETRIES = 5
+# minimum number of files failing download before starting to consider for failing
+# the scrape
+FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK = 50
+FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND = 1000  # 10 = 0.1% ; 1000 = 10%
+# 60000 = 60s max between file download attempts
+FILES_DOWNLOAD_MAX_INTERVAL = 60000

--- a/src/sotoki/utils/database/files.py
+++ b/src/sotoki/utils/database/files.py
@@ -1,0 +1,49 @@
+import json
+from dataclasses import dataclass
+
+import snappy
+
+from sotoki.utils.shared import shared
+
+
+@dataclass(kw_only=True)
+class File:
+    url: str
+    zim_path: str
+    download_attempts: int
+
+
+class FileDatabase:
+
+    def __init__(self, hostname: str):
+        self.hostname = hostname
+
+    @property
+    def _list_name(self) -> str:
+        return f"{self.hostname}-files"
+
+    def pop(self) -> File | None:
+        file = shared.database.safe_command("rpop", self._list_name)
+        if not file:
+            return None
+        file = json.loads(snappy.decompress(file))
+        return File(url=file[0], zim_path=file[1], download_attempts=file[2])
+
+    def push(self, file: File):
+        file_bytes = snappy.compress(
+            json.dumps(
+                (
+                    file.url,
+                    file.zim_path,
+                    file.download_attempts,
+                )
+            )
+        )
+
+        shared.database.safe_command("lpush", self._list_name, file_bytes)
+
+    def len(self) -> int:
+        return shared.database.safe_command("llen", self._list_name)
+
+    def flush(self):
+        shared.database.safe_command("delete", self._list_name)

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -4,26 +4,51 @@ import hashlib
 import io
 import re
 import urllib.parse
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from time import sleep
 from typing import Any
 
 import requests
-from kiwixstorage import KiwixStorage, NotFoundError
+from kiwixstorage import NotFoundError
 from PIL import Image
 from resizeimage.imageexceptions import ImageSizeError
 from zimscraperlib.download import stream_file
 from zimscraperlib.image.optimization import OptimizeWebpOptions, optimize_webp
 from zimscraperlib.image.probing import format_for
 from zimscraperlib.image.transformation import resize_image
-from zimscraperlib.typing import Callback
 
 from sotoki.constants import (
+    FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK,
+    FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND,
+    FILES_DOWNLOAD_MAX_INTERVAL,
     HTTP_REQUEST_TIMEOUT,
     IMAGES_ENCODER_VERSION,
+    MAX_FILE_DOWNLOAD_RETRIES,
     POSTS_IMAGE_SIZE,
     USER_AGENT,
 )
-from sotoki.utils.misc import web_backoff
+from sotoki.utils.database.files import File, FileDatabase
+from sotoki.utils.html import parse_retry_after_header
 from sotoki.utils.shared import context, logger, shared
+
+
+@dataclass(kw_only=True)
+class HostData:
+    files_to_download: FileDatabase
+    last_request_date: datetime | None = None
+    request_interval_milliseconds: float = 10
+    not_before_date: datetime | None = None
+    download_success: int = 0
+    download_failure: int = 0
+    downloads_complete: bool = False
+
+
+@dataclass(kw_only=True)
+class FileToDownload(File):
+    host_data: HostData
+    hostname: str
 
 
 class Imager:
@@ -32,18 +57,20 @@ class Imager:
         self.aborted = False
         self.handled = []
         self.nb_requested = 0
+        self.nb_failed = 0
         self.nb_done = 0
-        shared.img_executor.start()
+        self.filesDatabases: list[FileDatabase] = []
+        self.hosts: dict[str, HostData] = {}
+        self.hosts_with_bad_retry_after: set[str] = set()
 
     def abort(self):
         """request imager to cancel processing of futures"""
         self.aborted = True
 
-    @web_backoff
     def get_image_data(self, url: str, **resize_args: Any) -> tuple[io.BytesIO, str]:
         """Bytes stream of an optimized, resized WebP of the source image"""
         src, webp = io.BytesIO(), io.BytesIO()
-        stream_file(url=url, byte_stream=src)
+        stream_file(url=url, byte_stream=src, headers={"User-Agent": USER_AGENT})
         if format_for(src, from_suffix=False) == "SVG":
             return src, "image/svg+xml"
         # first resize then convert to webp and optimize, because conversion to webp
@@ -79,7 +106,6 @@ class Imager:
         """Unique identifier of that url"""
         return hashlib.md5(url.encode("UTF-8")).hexdigest()  # nosec # noqa: S324
 
-    @web_backoff
     def get_version_ident_for(self, url: str) -> str | None:
         """~version~ of the URL data to use for comparisons. Built from headers"""
         try:
@@ -89,17 +115,13 @@ class Imager:
             headers = resp.headers
         except Exception:
             logger.warning(f"Unable to HEAD {url}")
-            try:
-                _, headers = stream_file(
-                    url=url,
-                    headers={"User-Agent": USER_AGENT},
-                    byte_stream=io.BytesIO(),
-                    block_size=1,
-                    only_first_block=True,
-                )
-            except Exception:
-                logger.warning(f"Unable to query image at {url}")
-                return
+            _, headers = stream_file(
+                url=url,
+                headers={"User-Agent": USER_AGENT},
+                byte_stream=io.BytesIO(),
+                block_size=1,
+                only_first_block=True,
+            )
 
         for header in ("ETag", "Last-Modified", "Content-Length"):
             if headers.get(header):
@@ -127,13 +149,18 @@ class Imager:
             )
             return
 
-        # skip processing if we already processed it or have it in pipe
+        if not parsed_url.hostname:
+            logger.warning(
+                f"Not supporting empty image hostname `{parsed_url.geturl()}`. Skipping"
+            )
+            return
+
         digest = self.get_digest_for(parsed_url.geturl())
         if path is None:
             path = f"images/{digest}"
 
+        # do not add same image to process twice
         if digest in self.handled:
-            logger.debug(f"URL `{parsed_url.geturl()}` already processed.")
             return path
 
         # record that we are processing this one
@@ -141,64 +168,229 @@ class Imager:
 
         self.nb_requested += 1
 
-        shared.img_executor.submit(
-            self.process_image,
-            parsed_url=parsed_url,
-            path=path,
-            dont_release=True,
+        if parsed_url.hostname not in self.hosts:
+            files_to_download = FileDatabase(parsed_url.hostname)
+            self.filesDatabases.append(files_to_download)
+            files_to_download.flush()
+            self.hosts[parsed_url.hostname] = HostData(
+                files_to_download=files_to_download
+            )
+        self.hosts[parsed_url.hostname].files_to_download.push(
+            File(url=parsed_url.geturl(), zim_path=path, download_attempts=0)
         )
 
         return path
 
     def once_done(self):
         """default callback for single image processing"""
+        # logger.debug("Once DONE")
         self.nb_done += 1
-        shared.progresser.update()
+        shared.progresser.update(incr=1)
+
+    def process_images(self):
+        logger.info("Starting images download")
+        for hostname, host_data in self.hosts.items():
+            logger.info(f"- {hostname}: {host_data.files_to_download.len()}")
+        shared.progresser.start(
+            shared.progresser.IMAGES_STEP, nb_total=self.nb_requested
+        )
+        shared.img_executor.start()
+        for _ in range(shared.img_executor.nb_workers):
+            shared.img_executor.submit(self.worker_loop)
+        while not self.aborted and (self.nb_done + self.nb_failed) < self.nb_requested:
+            sleep(2)
+
+    def _get_next_file_to_download(self) -> FileToDownload | None:
+        while not self.aborted:
+            now = datetime.now(UTC)
+
+            # check if all downloads have completed and exit
+            if all(host.downloads_complete for host in self.hosts.values()):
+                logger.debug("all hosts have done all downloads")
+                return None
+
+            for hostname, host_data in self.hosts.items():
+                # check for conditions which leads to ignore current host
+                if (
+                    host_data.downloads_complete
+                    or (
+                        host_data.not_before_date is not None
+                        and host_data.not_before_date > now
+                    )
+                    or (
+                        host_data.last_request_date is not None
+                        and host_data.last_request_date
+                        + timedelta(
+                            milliseconds=host_data.request_interval_milliseconds
+                        )
+                        > now
+                    )
+                ):
+                    continue
+
+                # grab new file from Redis queue
+                file_to_download = host_data.files_to_download.pop()
+                if file_to_download is None:
+                    logger.debug(f"{hostname} has completed all its downloads")
+                    host_data.downloads_complete = True
+                    continue
+
+                # modify lastRequestDate immediately so that all workers are aware
+                host_data.last_request_date = now
+                return FileToDownload(
+                    url=file_to_download.url,
+                    zim_path=file_to_download.zim_path,
+                    download_attempts=file_to_download.download_attempts,
+                    host_data=host_data,
+                    hostname=hostname,
+                )
+
+            # pause few milliseconds, no host has something to process yet (just to not
+            # burn CPU)
+            sleep(0.01)
+
+    def worker_loop(self):
+        try:
+            while not self.aborted:
+                with shared.lock:
+                    next_file = self._get_next_file_to_download()
+                if next_file is None:
+                    break
+                self.process_image(next_file)
+            logger.debug("worker loop completed")
+        except Exception:
+            self.abort()
 
     def process_image(
         self,
-        *,
-        parsed_url: urllib.parse.ParseResult,
-        path: str,
-    ) -> str | None:
+        file: FileToDownload,
+    ):
         """download image from url or S3 and add to Zim at path. Upload if req."""
 
+        if (
+            self.nb_failed > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK
+            and (self.nb_failed * 10000) / self.nb_requested
+            > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
+        ):
+            raise Exception(
+                f"Too many files failed to download: [{self.nb_failed}/"
+                f"{self.nb_requested}]"
+            )
+
+        try:
+            self.download_image(file)
+        except requests.exceptions.RequestException as exc:
+            if isinstance(exc, requests.HTTPError):
+                err_details = f"HTTP error code {exc.response.status_code}"
+                err_status_code = exc.response.status_code
+            else:
+                err_details = str(exc)
+                err_status_code = None
+            if file.download_attempts > MAX_FILE_DOWNLOAD_RETRIES:
+                logger.warning(
+                    f"Error downloading file {file.url}, too many attempts failed, last"
+                    f" one failed with '{err_details}', skipping"
+                )
+                file.host_data.download_failure += 1
+                self.nb_failed += 1
+                return
+            if err_status_code == HTTPStatus.NOT_FOUND:
+                logger.warning(
+                    f"Error downloading file {file.url}, received a 404, skipping"
+                )
+                file.host_data.download_failure += 1
+                self.nb_failed += 1
+                return
+
+            if isinstance(exc, requests.HTTPError):
+                retry_after_header = exc.response.headers.get("Retry-After")
+                # ignore Retry-After header of some hosts giving bad values
+                if retry_after_header and file.hostname not in ["i.imgur.com"]:
+                    retry_date = parse_retry_after_header(retry_after_header)
+                    if retry_date:
+                        file.host_data.not_before_date = retry_date
+                        logger.info(
+                            f"Received a [Retry-After={retry_after_header}], pausing "
+                            f"down {file.hostname} until {retry_date}"
+                        )
+                    elif file.hostname not in self.hosts_with_bad_retry_after:
+                        self.hosts_with_bad_retry_after.add(file.hostname)
+                        logger.warning(
+                            f"Received a [Retry-After={retry_after_header}] from "
+                            f"{file.hostname} but failed to interpret it (other 'bad'"
+                            "Retry-After from this host will not issue a warning log)"
+                        )
+
+                if exc.response.status_code in [
+                    HTTPStatus.TOO_MANY_REQUESTS,
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    524,
+                ]:
+                    # 1.2 is arbitrary value to progressively slow requests to host down
+                    file.host_data.request_interval_milliseconds = min(
+                        FILES_DOWNLOAD_MAX_INTERVAL,
+                        file.host_data.request_interval_milliseconds * 1.2,
+                    )
+                    logger.info(
+                        f"Received a {exc.response.status_code} HTTP status for "
+                        f"{file.url}. Slowing down {file.hostname} to"
+                        f" {file.host_data.request_interval_milliseconds}ms interval"
+                        f" ({file.host_data.files_to_download.len()} files remaining"
+                        " to download from host)"
+                    )
+
+            # put file back in the queue
+            file.host_data.files_to_download.push(file)
+        except Exception:
+            logger.exception(f"Error downloading file {file.url}, skipping")
+            file.host_data.download_failure += 1
+            self.nb_failed += 1
+        else:
+            file.host_data.download_success += 1
+
+    def download_image(self, file: FileToDownload):
         if self.aborted:
             return
 
         # setup resizing based on request
         resize_args = {"width": POSTS_IMAGE_SIZE}
 
+        parsed_url = urllib.parse.urlparse(file.url)
+
         # just download, optimize and add to ZIM if not using S3
         if not context.s3_url_with_credentials:
+            file.download_attempts += 1
             image_content, image_mimetype = self.get_image_data(
                 parsed_url.geturl(), **resize_args
             )
             with shared.lock:
                 shared.creator.add_item_for(
-                    path=path,
+                    path=file.zim_path,
                     content=image_content.getvalue(),
                     mimetype=image_mimetype,
                     is_front=False,
-                    callbacks=[Callback(func=self.once_done)],
+                    # callbacks=Callback(func=self.once_done),
                 )
-            return path
+            self.once_done()
+            return
+
+        if not shared.s3_storage:
+            raise Exception("S3 storage should already have been initialized")
 
         # we are using S3 cache
         ident = self.get_version_ident_for(parsed_url.geturl())
         if ident is None:
             logger.error(f"Unable to query {parsed_url.geturl()}. Skipping")
-            return path
+            return
 
         key = self.get_s3_key_for(parsed_url.geturl())
-        s3_storage = KiwixStorage(context.s3_url_with_credentials)
         meta = {"ident": ident, "encoder_version": str(IMAGES_ENCODER_VERSION)}
 
         download_failed = False  # useful to trigger reupload or not
         try:
-            logger.debug(f"Attempting download of S3::{key} into ZIM::{path}")
+            logger.debug(f"Attempting download of S3::{key} into ZIM::{file.zim_path}")
             image_content = io.BytesIO()
-            s3_storage.download_matching_fileobj(key, image_content, meta=meta)
+            shared.s3_storage.download_matching_fileobj(key, image_content, meta=meta)
         except NotFoundError:
             # don't have it, not a donwload error. we'll upload after processing
             pass
@@ -210,41 +402,42 @@ class Imager:
             image_mimetype = format_for(image_content, from_suffix=False)
             with shared.lock:
                 shared.creator.add_item_for(
-                    path=path,
+                    path=file.zim_path,
                     content=image_content.getvalue(),
                     mimetype=image_mimetype,
                     is_front=False,
-                    callbacks=[Callback(func=self.once_done)],
+                    # callbacks=Callback(func=self.once_done),
                 )
-            return path
+            self.once_done()
+            return
+
+        if not key or not meta:
+            raise Exception("s3_key and s3_meta should have been populated")
 
         # we're using S3 but don't have it or failed to download
-        try:
-            image_content, image_mimetype = self.get_image_data(
-                parsed_url.geturl(), **resize_args
-            )
-        except Exception as exc:
-            logger.error(
-                f"Failed to download/convert/optim source  at {parsed_url.geturl()}"
-            )
-            logger.exception(exc)
-            return path
+        file.download_attempts += 1
+        image_content, image_mimetype = self.get_image_data(
+            parsed_url.geturl(), **resize_args
+        )
 
         with shared.lock:
             shared.creator.add_item_for(
-                path=path,
+                path=file.zim_path,
                 content=image_content.getvalue(),
                 mimetype=image_mimetype,
                 is_front=False,
-                callbacks=[Callback(func=self.once_done)],
+                # callbacks=Callback(func=self.once_done),
             )
+        self.once_done()
 
         # only upload it if we didn't have it in cache
         if not download_failed:
             logger.debug(f"Uploading {parsed_url.geturl()} to S3::{key} with {meta}")
             try:
-                s3_storage.upload_fileobj(fileobj=image_content, key=key, meta=meta)
+                shared.s3_storage.upload_fileobj(
+                    fileobj=image_content, key=key, meta=meta
+                )
             except Exception as exc:
                 logger.error(f"{key} failed to upload to cache: {exc}")
 
-        return path
+        return

--- a/src/sotoki/utils/progress.py
+++ b/src/sotoki/utils/progress.py
@@ -6,7 +6,7 @@ from collections import OrderedDict, namedtuple
 from typing import ClassVar
 
 from sotoki.context import Context
-from sotoki.utils.shared import logger, shared
+from sotoki.utils.shared import logger
 
 
 class Progresser:
@@ -30,6 +30,7 @@ class Progresser:
             (QUESTIONS_STEP, 3460),
             (TAGS_STEP, 10),
             (LISTS_STEP, 2),
+            (IMAGES_STEP, 5000),
         ]
     )
 
@@ -114,9 +115,6 @@ class Progresser:
             f"{self.current_step.title()} -- "
             f"{self.current_step_progress}/{self.current_step_total}"
         )
-
-        if self.images_progress:
-            msg += f" -- Images: {self.nb_img_done}"
         logger.info(msg)
         self.last_print_on = datetime.datetime.now(datetime.UTC)
 
@@ -165,29 +163,6 @@ class Progresser:
         """progress of current step (0-1)"""
         try:
             return min([self.current_step_progress / self.current_step_total, 1])
-        except ZeroDivisionError:
-            return 1
-
-    @property
-    def nb_img_requested(self):
-        return getattr(shared.imager, "nb_requested", 0)
-
-    @property
-    def nb_img_done(self):
-        return getattr(shared.imager, "nb_done", 0)
-
-    @property
-    def images_progress(self) -> float:
-        """progress of images step (0-1)"""
-        if self.nb_img_requested == 0:
-            return 0
-        try:
-            return min(
-                [
-                    self.nb_img_done / self.nb_img_requested,
-                    1,
-                ]
-            )
         except ZeroDivisionError:
             return 1
 

--- a/src/sotoki/utils/shared.py
+++ b/src/sotoki/utils/shared.py
@@ -6,8 +6,8 @@ import threading
 from threading import Lock
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from zimscraperlib.zim import Creator
+from kiwixstorage import KiwixStorage
+from zimscraperlib.zim import Creator
 
 from sotoki.context import Context
 
@@ -46,6 +46,7 @@ class Shared:
     lock: Lock = Lock()
     dump_domain: str
     online_domain: str
+    s3_storage: KiwixStorage | None
 
     # total stats
     total_tags = 0


### PR DESCRIPTION
Fix #326

Hopefully, this will also be the solution for #339, #341 and #342, but I can't say for sure since these are hard to reproduce locally.

Changes:
- For #341: add a backoff when getting site details, with significant delay and retries (we are not in a hurry at this stage)
- For images, move for the naive approach using backoff to an approach where we really handle download speed per hostname

Approach for images:
- stop processing images "on-the-fly" but do that after all other things have been processed: this ensures we have a clear progress status, clear failures, etc... ; it also ensures we do not slow down items (typically questions) processing because all image threads have been slowed down, which does not help understand scraper speed ; obviously total scrape time will be a bit higher, but I think the clarity is way superior for debugging, and it shouldn't be a big concern
- store images to download in one Redis queue per host, so that we can pop them, push them back to the queue when they failed, etc ... 
- process images with clear pause between requests on a single host
- properly pass headers to `stream_file` in all situations so that we achieve to download images from upload.wikimedia.org for instance
- add more logs, especially in debug mode
- nota: currently the logic does not care about how files are retrieved, from s3 cache or upstream, because even when we use the s3 cache we need to do a HEAD on upstream to get file ident ; a further optimization could be to separate processing of HEAD to upstream, GET from s3 cache and GET from upstream ; let's see if it is really necessary
