### PR TITLE
Implement speed up of images download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgrade to Python 3.14 + Debian bookworm (#351)
 - **BREAKING**: Replace usage of multiple `--tag` with single CSV `--tags` for Zimfarm integration (#351)
-- Enhance logic to download images to better respect upstream servers (#xxx)
+- Enhance logic to download images to better respect upstream servers (#367 and #369)
 
 ### Fixed
 

--- a/src/sotoki/constants.py
+++ b/src/sotoki/constants.py
@@ -38,3 +38,9 @@ FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK = 50
 FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND = 1000  # 10 = 0.1% ; 1000 = 10%
 # 60000 = 60s max between file download attempts
 FILES_DOWNLOAD_MAX_INTERVAL = 60000
+# 10 = 10ms min between file download attempts
+FILES_DOWNLOAD_MIN_INTERVAL = 10
+# consider speeding download a bit once this amount of files have succeeded to download
+FILES_DOWNLOAD_SPEED_UP_AFTER = 10
+FILES_DOWNLOAD_SPEED_UP_FACTOR = 1.1
+FILES_DOWNLOAD_SLOW_DOWN_FACTOR = 1.2


### PR DESCRIPTION
In https://github.com/openzim/sotoki/pull/367, we've implemented something to slow down image download.

The fact there is nothing to speed up when things seems to cool down is a kind of issue.

In this PR, we let scraper speed up a bit once many files have succeeded to download in a row.