### PR TITLE
Fix extraction of header on non-stackoverflow and non-stackexchange domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix extraction of header on non-stackoverflow and non-stackexchange domains (#385)
+
 ## [3.0.1] - 2025-12-18
 
 ### Fixed

--- a/src/sotoki/scraper.py
+++ b/src/sotoki/scraper.py
@@ -95,7 +95,7 @@ class StackExchangeToZim:
         if not title_tag or not title_tag.string:
             raise Exception("Failed to extract site title from homepage")
         site_title = title_tag.string
-        if "stackexchange" in context.domain:
+        if "stackoverflow" not in context.domain:
             # For "regular" stackexchange domains, use the whole header
             header_tag = soup.find("header", class_="site-header")
             if not header_tag:


### PR DESCRIPTION
While we have fixed header extraction for stackoverflow domains in https://github.com/openzim/sotoki/issues/378, it has broken header extraction for domains like askubuntu.com or stackapps.com

This PR fixes the situation.