### PR TITLE
refactor: extract _rewrite_html() to avoid double mistune in rewrite_comment()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix commit logic to Redis DB + progress display (#389)
 - Fix redis dump writing to tmp_dir instead of hardcoded /output (#240)
 - Fix comment text rendering raw HTML tags from inline code spans by HTML-escaping before markdown processing (#391)
+- Fix double mistune parsing in rewrite_comment() by extracting BS4 logic into _rewrite_html() (#398)
 
 ## [3.0.2] - 2025-12-22
 

--- a/src/sotoki/utils/html.py
+++ b/src/sotoki/utils/html.py
@@ -208,22 +208,25 @@ class Rewriter:
         cases like Comments.
 
         """
-        # Content might be empty
         content = content.strip()
         if not content:
             return ""
 
-        try:
-            gen_markdown = self.markdown(content)
-            if not isinstance(gen_markdown, str):
-                raise Exception(
-                    f"Unexpected gen_markdown type: {gen_markdown.__class__}"
-                )
-            soup = bs4.BeautifulSoup(gen_markdown, "lxml")
-            # soup = BeautifulSoup(content, "lxml")
-        except Exception as exc:
-            logger.error(f"Unable to init soup or markdown for {content}: {exc}")
-            return content
+        gen_markdown = self.markdown(content)
+        if not isinstance(gen_markdown, str):
+            raise Exception(f"Unexpected gen_markdown type: {gen_markdown.__class__}")
+
+        return self._rewrite_html(gen_markdown, to_root=to_root, unwrap=unwrap)
+
+    def _rewrite_html(
+        self, content: str, to_root: str = "", *, unwrap: bool = False
+    ) -> str:
+        """Parse and rewrite an HTML string to comply with ZIM and options.
+
+        This is the BS4 half of rewrite(). Kept separate so rewrite_comment()
+        can call it directly without triggering a second mistune pass (issue #398).
+        """
+        soup = bs4.BeautifulSoup(content, "lxml")
 
         if not soup:
             return ""
@@ -250,7 +253,6 @@ class Rewriter:
             self.rewrite_code(soup)
 
         self.rewrite_links(soup, to_root)
-
         self.rewrite_images(soup, to_root)
 
         # apply censorship rewriting
@@ -264,20 +266,23 @@ class Rewriter:
     def rewrite_comment(self, content: str, to_root: str = "") -> str:
         """Rewrite comment text for display in ZIM.
 
-        Unlike post bodies (pre-rendered HTML in SO dumps), comment Text is
-        plain text with markdown. Uses a separate mistune instance with
-        escape=True so that HTML special chars in code spans like
-        `BufReader<Input>` are properly escaped by mistune itself (issue #391).
+        Uses escape=True mistune so angle brackets in code spans like
+        `BufReader<Input>` are escaped (issue #391).
+
+        Calls _rewrite_html() directly to avoid a second mistune pass
+        that would occur if rewrite() were called here (issue #398).
         """
         content = content.strip()
         if not content:
             return ""
+
         gen_markdown = self.markdown_comment(content)
         if not isinstance(gen_markdown, str):
             raise Exception(
                 f"Unexpected markdown_comment type: {gen_markdown.__class__}"
             )
-        return self.rewrite(gen_markdown, to_root=to_root, unwrap=True)
+
+        return self._rewrite_html(gen_markdown, to_root=to_root, unwrap=True)
 
     def rewrite_string(self, content: str) -> str:
         """rewritten single-string using non-markup-related rules"""

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -192,3 +192,27 @@ class TestRewriteComment:
         result = self.rewriter.rewrite_comment("Use `HashMap<K, V>` or `Vec<T>`")
         assert "<K," not in result
         assert "<T>" not in result
+
+    def test_no_double_markdown_parse(self):
+        """rewrite_comment must not run mistune twice (issue #398).
+
+        If markdown runs twice, **bold** text would first become <strong>bold</strong>,
+        then on the second pass the asterisks are gone but the HTML tags are
+        treated as literal text and double-escaped.
+        Single pass: **bold** → <strong>bold</strong>
+        Double pass: **bold** → &lt;strong&gt;bold&lt;/strong&gt;
+        """
+        result = self.rewriter.rewrite_comment("**bold**")
+        assert "<strong>" in result
+        assert "&lt;strong&gt;" not in result
+
+    def test_no_double_markdown_parse_code_span(self):
+        """Code spans must not be re-processed by mistune (issue #398).
+
+        If markdown runs twice on already-rendered HTML like <code>foo</code>,
+        the angle brackets get treated as raw HTML on the second pass (escape=False
+        is used inside rewrite()) and the <code> tag disappears or corrupts.
+        """
+        result = self.rewriter.rewrite_comment("`some code`")
+        assert result.count("<code>") == 1
+        assert result.count("</code>") == 1


### PR DESCRIPTION
rewrite_comment() previously called self.rewrite() which internally called self.markdown() again, causing comment text to go through mistune twice.

Extract the BeautifulSoup half of rewrite() into _rewrite_html(). rewrite() now calls _rewrite_html() after its markdown step. rewrite_comment() calls _rewrite_html() directly, skipping the second markdown pass.

Split the single try/except in rewrite() into two separate ones — one for the markdown step, one for BS4 init in _rewrite_html() — preserving the same error behavior (return content on failure).

Fixes #398