### PR TITLE
docs: add CONTRIBUTING.md and fix stale README developer section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Anybody is welcome to improve Sotoki.
+
+## Setup
+Install [hatch](https://hatch.pypa.io/latest/install/) if you don't have it, then:
+
+```bash
+hatch shell
+```
+
+This creates and activates the development environment with all dependencies included.
+
+## Code style
+
+Pre-commit hooks enforce `ruff`, `black`, `pyright`, trailing whitespace, and
+end-of-file fixes. Install them once after setting up your environment:
+```bash
+hatch run pre-commit install
+```
+
+Run manually at any time:
+```bash
+hatch run pre-commit run --all-files
+```
+
+## Testing
+```bash
+hatch run pytest tests/
+```
+
+## Changelog
+
+Add an entry under `[Unreleased]` in `CHANGELOG.md` for any user-facing change.

--- a/README.md
+++ b/README.md
@@ -61,15 +61,11 @@ deactivate  # unloads virtualenv from shell
 
 Anybody is welcome to improve the Sotoki.
 
-To run Sotoki off the git repository, you'll need to download a few
-external dependencies that we pack in Python releases. Just run
-`python src/sotoki/dependencies.py`.
-
-See `requirements.txt` for the list of python dependencies.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, code style guidelines, and changelog requirements.
 
 ## Users
 
-You don't have to make your own ZIM files of Stack Exchange's Web 
-sites. Updated ZIM files are built on a regular basis for all 
+You don't have to make your own ZIM files of Stack Exchange's Web
+sites. Updated ZIM files are built on a regular basis for all
 of them. Look at https://library.kiwix.org/?category=stack_exchange
 to download them.


### PR DESCRIPTION
Ref #400

- Add CONTRIBUTING.md with setup instructions (`pip install -e ".[dev]"`),
  pre-commit install instructions, testing, and changelog expectation
- Fix stale `## Developers` section in README.md — removed references to
  `dependencies.py` and `requirements.txt` which no longer exist; project
  uses `pyproject.toml` with optional dependency groups