### PR TITLE
Fix/user profile links without profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix redis dump writing to tmp_dir instead of hardcoded /output (#240)
 - Fix comment text rendering raw HTML tags from inline code spans by HTML-escaping before markdown processing (#391)
 - Fix double mistune parsing in rewrite_comment() by extracting BS4 logic into _rewrite_html() (#398)
+- Fix user profile links being rewritten instead of removed when `--without-user-profiles` is set (#247)
 
 ## [3.0.2] - 2025-12-22
 

--- a/src/sotoki/utils/html.py
+++ b/src/sotoki/utils/html.py
@@ -31,7 +31,7 @@ def get_text(content: str, strip_at: int = -1):
     # Normalize whitespace: replace all whitespace sequences with single space
     text = " ".join(text.split())
     if strip_at > 0 and len(text) > strip_at:
-        text = f'{text[0:strip_at].rsplit(" ", 1)[0]}…'
+        text = f"{text[0:strip_at].rsplit(' ', 1)[0]}…"
     # Escape HTML entities so the text is safe to use in HTML documents
     return html.escape(text)
 
@@ -293,7 +293,6 @@ class Rewriter:
     def rewrite_links(self, soup, to_root):
         # rewrite links targets
         for link in soup.find_all("a", href=True):
-
             # remove link to "" as the use of a <base /> in our template
             # would turn it into a link to root
             if not link.get("href", "").strip():
@@ -451,6 +450,9 @@ class Rewriter:
         # > rewrite to users/{uId}/{slug}
         uid_slug_m = self.uid_re.match(uri_path)
         if uid_slug_m:
+            if context.without_user_profiles:
+                del link.attrs["href"]
+                return
             uid = uid_slug_m.groupdict().get("user_id")
             if not isinstance(uid, str):
                 raise Exception(f"Unexpected uid type: {uid.__class__}")
@@ -528,7 +530,6 @@ class Rewriter:
                 del img.attrs["src"]
             # process all images
             else:
-
                 # skip links inside <code /> nodes
                 if is_in_code(img):
                     continue
@@ -583,8 +584,9 @@ class Rewriter:
         # now apply filtering on tag attributes. As per SE rules, users can only
         # set `alt` and `title` on <img />` and `title` on `<a />`
         for tag in soup.find_all(
-            lambda x: x.name in ("a", "img")
-            and (x.has_attr("title") or x.has_attr("alt"))
+            lambda x: (
+                x.name in ("a", "img") and (x.has_attr("title") or x.has_attr("alt"))
+            )
         ):
             for attr in ("title", "alt"):
                 if tag.attrs.get(attr):

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from sotoki.utils import html as html_module
 from sotoki.utils.html import Rewriter, get_text
 from sotoki.utils.shared import shared
 
@@ -160,7 +161,6 @@ class TestRewriteComment:
 
     @pytest.fixture(autouse=True)
     def _setup(self, monkeypatch):
-
         monkeypatch.setattr(shared, "online_domain", "example.com", raising=False)
         monkeypatch.setattr(
             shared, "site_details", MagicMock(highlight=False), raising=False
@@ -216,3 +216,43 @@ class TestRewriteComment:
         result = self.rewriter.rewrite_comment("`some code`")
         assert result.count("<code>") == 1
         assert result.count("</code>") == 1
+
+
+class TestRewriteUserProfileLinks:
+    """Test that user profile links are removed when --without-user-profiles is set."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch):
+        monkeypatch.setattr(shared, "online_domain", "example.com", raising=False)
+        monkeypatch.setattr(
+            shared, "site_details", MagicMock(highlight=False), raising=False
+        )
+        # mock usersdatabase to return a user
+        mock_user = {"name": "Test User"}
+        monkeypatch.setattr(
+            shared,
+            "usersdatabase",
+            MagicMock(get_user_full=MagicMock(return_value=mock_user)),
+            raising=False,
+        )
+        self.rewriter = Rewriter()
+
+    def test_user_link_kept_with_profiles(self, monkeypatch):
+        """
+        User profile links should be rewritten when without_user_profiles is False.
+        """
+
+        monkeypatch.setattr(html_module.context, "without_user_profiles", False)
+        result = self.rewriter.rewrite(
+            '<a href="/users/43968/reid-evans">reid-evans</a>', to_root=""
+        )
+        assert "href=" in result
+
+    def test_user_link_removed_without_profiles(self, monkeypatch):
+        """User profile links should be removed when without_user_profiles is True."""
+
+        monkeypatch.setattr(html_module.context, "without_user_profiles", True)
+        result = self.rewriter.rewrite(
+            '<a href="/users/43968/reid-evans">reid-evans</a>', to_root=""
+        )
+        assert "href=" not in result


### PR DESCRIPTION
Fixes #247

## Problem
When `--without-user-profiles` is used, links to user profile pages at
the end of posts were still being rewritten to internal ZIM paths instead
of being removed. This caused broken links in the ZIM since the target
pages don't exist.

## Root cause
In `rewrite_links()` in `src/sotoki/utils/html.py`, the user profile
link rewriting block didn't check `context.without_user_profiles` before
rewriting the href — it always rewrote regardless of the flag.

## Fix
Delete the href attribute instead of rewriting it when
`context.without_user_profiles` is True.

## Tests
Added two tests to `tests/utils/test_html.py` covering both cases:
- Link is rewritten when `without_user_profiles` is False
- Link href is removed when `without_user_profiles` is True