### PR TITLE
fix: retry pipe.execute() on ConnectionError in commit() and teardown()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix comment text rendering raw HTML tags from inline code spans by HTML-escaping before markdown processing (#391)
 - Fix double mistune parsing in rewrite_comment() by extracting BS4 logic into _rewrite_html() (#398)
 - Fix user profile links being rewritten instead of removed when `--without-user-profiles` is set (#247)
+- Fix commit() and teardown() failing fatally on transient Redis ConnectionError by retrying pipe.execute() (#387)
 
 ## [3.0.2] - 2025-12-22
 

--- a/src/sotoki/utils/database/redisdb.py
+++ b/src/sotoki/utils/database/redisdb.py
@@ -111,14 +111,25 @@ class RedisDatabase:
                 threading.Event().wait(2)
         return func(*args)
 
-    def commit(self, *, done=False):
-        self.pipe.execute()
+    def _execute_pipe_with_retry(self, pipe, retries: int = 20):
+        """Pipeline execute() retried on ConnectionError"""
+        attempt = 1
+        while attempt < retries:
+            try:
+                return pipe.execute()
+            except redis.exceptions.ConnectionError as exc:
+                logger.error(f"Redis PIPE.EXECUTE Error #{attempt}/{retries}: {exc}")
+                attempt += 1
+                threading.Event().wait(2)
+        return pipe.execute()
 
+    def commit(self, *, done=False):
+        self._execute_pipe_with_retry(self.pipe)
         # make sure we've commited pipes on all thread-specific pipelines
         if done:
             time.sleep(2)  # prevent last-thread created while we iterate on mini domain
             for pipe in self.pipes.values():
-                pipe.execute()
+                self._execute_pipe_with_retry(pipe)
 
     def purge(self):
         """ask redis to reclaim dirty pages space. Effective only on Linux"""
@@ -151,7 +162,7 @@ class RedisDatabase:
         self.conn.save()
 
     def teardown(self):
-        self.pipe.execute()
+        self._execute_pipe_with_retry(self.pipe)
         self.conn.close()
 
     def remove(self):

--- a/tests/utils/test_redisdb.py
+++ b/tests/utils/test_redisdb.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+import redis.exceptions
 
 from sotoki.utils.database.redisdb import RedisDatabase
 from sotoki.utils.shared import context
@@ -39,3 +40,76 @@ def test_dump_sets_dir_before_save(redis_db):
     ):
         redis_db.dump()
     assert call_order == ["config_set", "save"]
+
+
+def test_execute_pipe_with_retry_succeeds_first_attempt(redis_db):
+    """_execute_pipe_with_retry() calls pipe.execute() once when no error occurs"""
+    mock_pipe = MagicMock()
+    redis_db._execute_pipe_with_retry(mock_pipe)
+    mock_pipe.execute.assert_called_once()
+
+
+def test_execute_pipe_with_retry_retries_on_connection_error(redis_db):
+    """_execute_pipe_with_retry() retries after ConnectionError then succeeds"""
+
+    mock_pipe = MagicMock()
+    mock_pipe.execute.side_effect = [
+        redis.exceptions.ConnectionError("reset"),
+        None,
+    ]
+    with patch("threading.Event"):
+        redis_db._execute_pipe_with_retry(mock_pipe, retries=5)
+    assert mock_pipe.execute.call_count == 2
+
+
+def test_execute_pipe_with_retry_exhausts_retries(redis_db):
+    """_execute_pipe_with_retry() re-raises after exhausting all retries"""
+
+    mock_pipe = MagicMock()
+    mock_pipe.execute.side_effect = redis.exceptions.ConnectionError("reset")
+    with patch("threading.Event"), pytest.raises(redis.exceptions.ConnectionError):
+        redis_db._execute_pipe_with_retry(mock_pipe, retries=3)
+    assert mock_pipe.execute.call_count == 3
+
+
+def test_commit_retries_on_connection_error(redis_db):
+    """commit() retries pipe.execute() on ConnectionError"""
+
+    mock_pipe = MagicMock()
+    mock_pipe.execute.side_effect = [
+        redis.exceptions.ConnectionError("reset"),
+        None,
+    ]
+    with (
+        patch.object(
+            type(redis_db), "pipe", new_callable=lambda: property(lambda _: mock_pipe)
+        ),
+        patch("threading.Event"),
+    ):
+        redis_db.commit()
+    assert mock_pipe.execute.call_count == 2
+
+
+def test_commit_done_retries_all_pipes(redis_db):
+    """commit(done=True) retries execute() on all thread pipelines"""
+
+    mock_pipe_a = MagicMock()
+    mock_pipe_b = MagicMock()
+    mock_pipe_a.execute.side_effect = [
+        redis.exceptions.ConnectionError("reset"),
+        None,
+    ]
+    mock_pipe_b.execute.return_value = None
+    redis_db.pipes = {1: mock_pipe_a, 2: mock_pipe_b}
+
+    with (
+        patch.object(
+            type(redis_db), "pipe", new_callable=lambda: property(lambda _: MagicMock())
+        ),
+        patch("time.sleep"),
+        patch("threading.Event"),
+    ):
+        redis_db.commit(done=True)
+
+    assert mock_pipe_a.execute.call_count == 2
+    assert mock_pipe_b.execute.call_count == 1


### PR DESCRIPTION
Ref #387

commit() and teardown() called pipe.execute() with no retry protection. safe_command() already has 20-retry logic on ConnectionError but commit() had none — making a transient reset always fatal, worst at commit(done=True) which is the final bulk flush after all workers join.

Extracted _execute_pipe_with_retry() mirroring safe_command()'s pattern and used it in commit() (both call sites) and teardown().