### PR TITLE
Fix issue with bad SVG being cached in S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix user profile links being rewritten instead of removed when `--without-user-profiles` is set (#247)
 - Fix commit() and teardown() failing fatally on transient Redis ConnectionError by retrying pipe.execute() (#387)
 - Adding a new image to process is O(N) instead of O(1) (#407)
+- Fix issue with bad SVG being cached in S3 (#410)
 
 ## [3.0.2] - 2025-12-22
 

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import requests
 from kiwixstorage import NotFoundError
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from resizeimage.imageexceptions import ImageSizeError
 from zimscraperlib.download import stream_file
 from zimscraperlib.image.optimization import OptimizeWebpOptions, optimize_webp
@@ -76,6 +76,7 @@ class Imager:
         src, webp = io.BytesIO(), io.BytesIO()
         stream_file(url=url, byte_stream=src, headers={"User-Agent": USER_AGENT})
         if format_for(src, from_suffix=False) == "SVG":
+            src.seek(0)
             return src, "image/svg+xml"
         # first resize then convert to webp and optimize, because conversion to webp
         # proved to consume lots of memory ; a smaller image obviously consumes less
@@ -418,16 +419,23 @@ class Imager:
             # Attempting download from S3
             image_content = io.BytesIO()
             shared.s3_storage.download_matching_fileobj(key, image_content, meta=meta)
+            image_mimetype = format_for(image_content, from_suffix=False)
         except NotFoundError:
             # don't have it, not a download error. we'll upload after processing
             pass
+        except UnidentifiedImageError:
+            # problem decoding image => S3 cache is probably corrupted => let's
+            # download and cache new version in S3
+            logger.warning(
+                f"failed to identify image mimetype from cache key {key}",
+                exc_info=context.debug,
+            )
         except Exception as exc:
             logger.warning(
                 f"failed to download {key} from cache: {exc}", exc_info=context.debug
             )
             download_failed = True
         else:
-            image_mimetype = format_for(image_content, from_suffix=False)
             with shared.lock:
                 shared.creator.add_item_for(
                     path=file.zim_path,


### PR DESCRIPTION
Fix #410

Changes:
- until https://github.com/openzim/python-scraperlib/issues/296 is fixed (if we decide to), we need to `.seek(0)` after checking for SVG format
- if we encounter a PIL issue when decoding image, then we can assume the image is corrupted in S3 and should try to download from upstream again and upload again to S3 cache