### PR TITLE
Enhance handling of Cloudflare throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix commit() and teardown() failing fatally on transient Redis ConnectionError by retrying pipe.execute() (#387)
 - Adding a new image to process is O(N) instead of O(1) (#407)
 - Fix issue with bad SVG being cached in S3 (#410)
+- Enhance handling of Cloudflare throttling (#403)
 
 ## [3.0.2] - 2025-12-22
 

--- a/src/sotoki/constants.py
+++ b/src/sotoki/constants.py
@@ -40,6 +40,7 @@ FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND = 1000  # 10 = 0.1% ; 1000 = 10
 FILES_DOWNLOAD_MAX_INTERVAL = 60000
 # 10 = 10ms min between file download attempts
 FILES_DOWNLOAD_MIN_INTERVAL = 10
+FILES_DOWNLOAD_INITIAL_INTERVAL = 10000
 # consider speeding download a bit once this amount of files have succeeded to download
 FILES_DOWNLOAD_SPEED_UP_AFTER = 10
 FILES_DOWNLOAD_SPEED_UP_FACTOR = 1.1

--- a/src/sotoki/utils/imager.py
+++ b/src/sotoki/utils/imager.py
@@ -22,6 +22,7 @@ from zimscraperlib.image.transformation import resize_image
 from sotoki.constants import (
     FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK,
     FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND,
+    FILES_DOWNLOAD_INITIAL_INTERVAL,
     FILES_DOWNLOAD_MAX_INTERVAL,
     FILES_DOWNLOAD_MIN_INTERVAL,
     FILES_DOWNLOAD_SLOW_DOWN_FACTOR,
@@ -42,7 +43,7 @@ from sotoki.utils.shared import context, logger, shared
 class HostData:
     files_to_download: FileDatabase
     last_request_date: datetime | None = None
-    request_interval_milliseconds: float = FILES_DOWNLOAD_MIN_INTERVAL
+    request_interval_milliseconds: float = FILES_DOWNLOAD_INITIAL_INTERVAL
     not_before_date: datetime | None = None
     download_success: int = 0
     download_failure: int = 0
@@ -349,6 +350,7 @@ class Imager:
                 if exc.response.status_code in [
                     HTTPStatus.TOO_MANY_REQUESTS,
                     HTTPStatus.SERVICE_UNAVAILABLE,
+                    HTTPStatus.FORBIDDEN,  # Many CDNs return 403 when blocking
                     524,
                 ]:
                     file.host_data.request_interval_milliseconds = min(


### PR DESCRIPTION
Fix #403

Changes:
- include `403` in codes causing scraper to slow-down on a given host
- start with a default of 10 seconds between requests for images on a given host (instead of the minimum of 10ms) and increase pace slowly (or slow even further if already throttled) to avoid being blocked immediately