### PR TITLE
Automatically remove control characters in Post titles and HTML tags title and alt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhance handling of Cloudflare throttling (#403)
 - Fix bug in get_version_ident_for fallback to GET method (#413)
 - Do not use scraperlib callbacks to inform about scraper progress (#370)
+- Automatically remove control characters in Post titles and HTML tags title and alt (#418)
 
 ## [3.0.2] - 2025-12-22
 

--- a/src/sotoki/utils/html.py
+++ b/src/sotoki/utils/html.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 
 import bs4
 import mistune
+import regex
 from slugify import slugify
 from tld import get_fld
 
@@ -286,6 +287,9 @@ class Rewriter:
 
     def rewrite_string(self, content: str) -> str:
         """rewritten single-string using non-markup-related rules"""
+        # remove any control character
+        content = regex.sub(r"\p{C}+", " ", content).strip()
+        # replace censored words
         if context.censor_words_list:
             return self.words_re.sub(self.redacted_text, content)
         return content


### PR DESCRIPTION
Fix #418 

Changes:
- automatically sub control characters in post titles with a single space (including carriage return, tabs, ... which we do not want in titles)
- same `rewrite_string` method used to clean post titles is also used for HTML tags `title` and `alt` (typically images) ; these will be cleaned from control characters as well, which is not a bad thing IMHO (not sure it does happen but who knows ...)